### PR TITLE
Fixed a broken example in the QuickStart.md documentation

### DIFF
--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -233,7 +233,7 @@ context.SomePolicy(new Config()
 Cool! We have a more complex policy document. Now let's compile it to a policy document.
 
 ```shell
-dotnet azure-apim-policy-compiler --s .\source --o . --format true
+dotnet azure-apim-policy-compiler --s .\source\ --o . --format true
 ```
 
 Content of the generated file should be:


### PR DESCRIPTION
The example compile command in QuickStart.md doesn't work with the 0.0.1 release of the toolkit.

A trailing slash is required for it to work properly.

Also, my team used the policy toolkit this week to add unit testing to our policies. This tool is fantastic.