### PR TITLE
fix: Remove config validation in constructors

### DIFF
--- a/src/Authoring/Configs/ForwardRequestConfig.cs
+++ b/src/Authoring/Configs/ForwardRequestConfig.cs
@@ -52,12 +52,4 @@ public record ForwardRequestConfig
     /// When set to true, triggers on-error section for response codes in the range from 400 to 599 inclusive. Policy expressions aren't allowed.
     /// </summary>
     public bool? FailOnErrorStatusCode { get; init; }
-
-    public ForwardRequestConfig()
-    {
-        if (Timeout.HasValue && TimeoutMs.HasValue)
-        {
-            throw new ArgumentException("You can specify either timeout or timeout-ms but not both.");
-        }
-    }
 }

--- a/src/Authoring/Configs/RateLimitConfig.cs
+++ b/src/Authoring/Configs/RateLimitConfig.cs
@@ -32,12 +32,4 @@ public abstract record EntityLimitConfig
     public string? Id { get; init; }
     public required int Calls { get; init; }
     public required int RenewalPeriod { get; init; }
-
-    public EntityLimitConfig()
-    {
-        if (Name is null && Id is null)
-        {
-            throw new ArgumentNullException("Name or Id need to be specified");
-        }
-    }
 }

--- a/src/Authoring/Configs/SetBackendServiceConfig.cs
+++ b/src/Authoring/Configs/SetBackendServiceConfig.cs
@@ -11,12 +11,4 @@ public record SetBackendServiceConfig
     public string? SfServiceInstanceName { get; init; }
     public string? SfPartitionKey { get; init; }
     public string? SfListenerName { get; init; }
-    
-    public SetBackendServiceConfig()
-    {
-        if (BaseUrl == null && BackendId == null || BaseUrl != null && BackendId != null)
-        {
-            throw new ArgumentException("You need to specify either base-url or backend-id but not both.");
-        }
-    }
 }

--- a/src/Authoring/Configs/ValidateJwtConfig.cs
+++ b/src/Authoring/Configs/ValidateJwtConfig.cs
@@ -23,14 +23,6 @@ public record ValidateJwtConfig
     public string[]? Audiences { get; init; }
     public string[]? Issuers { get; init; }
     public ClaimConfig[]? RequiredClaims { get; init; }
-
-    public ValidateJwtConfig()
-    {
-        if (new[] { HeaderName, QueryParameterName, TokenValue }.Count(string.IsNullOrEmpty) != 1)
-        {
-            throw new ArgumentException("Only one of HeaderName, QueryParameterName and TokenValue must be set");
-        }
-    }
 }
 
 public record OpenIdConfig


### PR DESCRIPTION
Fixes #55 
Constructor is executed before the fields are assigned. Because of this we cannot do the validation in the constructor.