### PR TITLE
Add get-authorization-context policy support

### DIFF
--- a/src/Authoring/Configs/GetAuthorizationContextConfig.cs
+++ b/src/Authoring/Configs/GetAuthorizationContextConfig.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.ApiManagement.PolicyToolkit.Authoring;
+
+/// <summary>
+/// Configuration for the get-authorization-context policy.
+/// </summary>
+public record GetAuthorizationContextConfig
+{
+    /// <summary>
+    /// The credential provider resource identifier. Policy expressions are allowed.
+    /// </summary>
+    public required string ProviderId { get; init; }
+
+    /// <summary>
+    /// The connection resource identifier. Policy expressions are allowed.
+    /// </summary>
+    public required string AuthorizationId { get; init; }
+
+    /// <summary>
+    /// The name of the context variable to receive the Authorization object. Policy expressions are allowed.
+    /// </summary>
+    public required string ContextVariableName { get; init; }
+
+    /// <summary>
+    /// Type of identity to check against the connection's access policy. Default is "managed".
+    /// </summary>
+    public string? IdentityType { get; init; } = "managed";
+
+    /// <summary>
+    /// A Microsoft Entra JWT bearer token to check against the connection permissions. Ignored for identity-type other than jwt.
+    /// </summary>
+    public string? Identity { get; init; }
+
+    /// <summary>
+    /// Boolean. If acquiring the authorization context results in an error, the context variable is assigned a value of null if true, otherwise return 500. Default is false.
+    /// </summary>
+    public bool? IgnoreError { get; init; } = false;
+}

--- a/src/Authoring/Expressions/Authorization.cs
+++ b/src/Authoring/Expressions/Authorization.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.ApiManagement.PolicyToolkit.Authoring.Expressions;
+
+/// <summary>
+/// Represents an authorization object with access token and claims.
+/// </summary>
+public class Authorization
+{
+    /// <summary>
+    /// Gets the bearer access token to authorize a backend HTTP request.
+    /// </summary>
+    public string AccessToken { get; }
+
+    /// <summary>
+    /// Gets the claims returned from the authorization server's token response API.
+    /// </summary>
+    public IReadOnlyDictionary<string, object> Claims { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Authorization"/> class.
+    /// </summary>
+    /// <param name="accessToken">The bearer access token.</param>
+    /// <param name="claims">The claims returned from the authorization server's token response API.</param>
+    public Authorization(string accessToken, IReadOnlyDictionary<string, object> claims)
+    {
+        AccessToken = accessToken;
+        Claims = claims;
+    }
+}

--- a/src/Authoring/IInboundContext.cs
+++ b/src/Authoring/IInboundContext.cs
@@ -275,4 +275,10 @@ public interface IInboundContext : IHaveExpressionContext
     /// <param name="from">The string to be replaced. Policy expressions are allowed.</param>
     /// <param name="to">The string to replace with. Policy expressions are allowed.</param>
     void FindAndReplace(string from, string to);
+
+    /// <summary>
+    /// The get-authorization-context policy retrieves an authorization context from a specified provider.
+    /// </summary>
+    /// <param name="config">The configuration for the get-authorization-context policy.</param>
+    void GetAuthorizationContext(GetAuthorizationContextConfig config);
 }

--- a/src/Core/Compiling/CSharpPolicyCompiler.cs
+++ b/src/Core/Compiling/CSharpPolicyCompiler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Reflection;

--- a/src/Core/Compiling/Policy/GetAuthorizationContextCompiler.cs
+++ b/src/Core/Compiling/Policy/GetAuthorizationContextCompiler.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Xml.Linq;
+
+using Azure.ApiManagement.PolicyToolkit.Authoring;
+using Azure.ApiManagement.PolicyToolkit.Compiling.Diagnostics;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Azure.ApiManagement.PolicyToolkit.Compiling.Policy;
+
+public class GetAuthorizationContextCompiler : IMethodPolicyHandler
+{
+    public string MethodName => nameof(IInboundContext.GetAuthorizationContext);
+
+    public void Handle(ICompilationContext context, InvocationExpressionSyntax node)
+    {
+        if (!node.TryExtractingConfigParameter<GetAuthorizationContextConfig>(
+                context,
+                "get-authorization-context",
+                out var values))
+        {
+            return;
+        }
+
+        var element = new XElement("get-authorization-context");
+
+        if (!element.AddAttribute(values, nameof(GetAuthorizationContextConfig.ProviderId), "provider-id"))
+        {
+            context.Report(Diagnostic.Create(
+                CompilationErrors.RequiredParameterNotDefined,
+                node.GetLocation(),
+                "get-authorization-context",
+                nameof(GetAuthorizationContextConfig.ProviderId)
+            ));
+            return;
+        }
+
+        if (!element.AddAttribute(values, nameof(GetAuthorizationContextConfig.AuthorizationId), "authorization-id"))
+        {
+            context.Report(Diagnostic.Create(
+                CompilationErrors.RequiredParameterNotDefined,
+                node.GetLocation(),
+                "get-authorization-context",
+                nameof(GetAuthorizationContextConfig.AuthorizationId)
+            ));
+            return;
+        }
+
+        if (!element.AddAttribute(values, nameof(GetAuthorizationContextConfig.ContextVariableName), "context-variable-name"))
+        {
+            context.Report(Diagnostic.Create(
+                CompilationErrors.RequiredParameterNotDefined,
+                node.GetLocation(),
+                "get-authorization-context",
+                nameof(GetAuthorizationContextConfig.ContextVariableName)
+            ));
+            return;
+        }
+
+        element.AddAttribute(values, nameof(GetAuthorizationContextConfig.IdentityType), "identity-type");
+        element.AddAttribute(values, nameof(GetAuthorizationContextConfig.Identity), "identity");
+        element.AddAttribute(values, nameof(GetAuthorizationContextConfig.IgnoreError), "ignore-error");
+
+        context.AddPolicy(element);
+    }
+}

--- a/test/Test.Core/Compiling/GetAuthorizationContextTests.cs
+++ b/test/Test.Core/Compiling/GetAuthorizationContextTests.cs
@@ -1,0 +1,173 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+using Azure.ApiManagement.PolicyToolkit.Authoring;
+using Azure.ApiManagement.PolicyToolkit.Compiling;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Azure.Api.Management.PolicyToolkit.Tests.Compiling
+{
+    [TestClass]
+    public class GetAuthorizationContextTests
+    {
+        [DataTestMethod]
+        [DataRow(
+            @"
+                using Azure.Api.Management.PolicyToolkit.Authoring;
+
+                public class TestDocument : IDocument
+                {
+                    public void Inbound(IInboundContext context)
+                    {
+                        context.GetAuthorizationContext(new GetAuthorizationContextConfig
+                        {
+                            ProviderId = ""provider-id"",
+                            AuthorizationId = ""authorization-id"",
+                            ContextVariableName = ""context-variable-name""
+                        });
+                    }
+                }
+            ",
+            "provider-id", "authorization-id", "context-variable-name", null, null, null)]
+        [DataRow(
+            @"
+                using Azure.Api.Management.PolicyToolkit.Authoring;
+
+                public class TestDocument : IDocument
+                {
+                    public void Inbound(IInboundContext context)
+                    {
+                        context.GetAuthorizationContext(new GetAuthorizationContextConfig
+                        {
+                            ProviderId = ""provider-id"",
+                            AuthorizationId = ""authorization-id"",
+                            ContextVariableName = ""context-variable-name"",
+                            IdentityType = ""jwt"",
+                            Identity = ""jwt-token"",
+                            IgnoreError = true
+                        });
+                    }
+                }
+            ",
+            "provider-id", "authorization-id", "context-variable-name", "jwt", "jwt-token", "true")]
+        [DataRow(
+            @"
+                using Azure.Api.Management.PolicyToolkit.Authoring;
+
+                public class TestDocument : IDocument
+                {
+                    public void Inbound(IInboundContext context)
+                    {
+                        context.GetAuthorizationContext(new GetAuthorizationContextConfig
+                        {
+                            ProviderId = ""@(context.Variables[""provider-id""])"",
+                            AuthorizationId = ""@(context.Variables[""authorization-id""])"",
+                            ContextVariableName = ""@(context.Variables[""context-variable-name""])""
+                        });
+                    }
+                }
+            ",
+            "@(context.Variables[\"provider-id\"])", "@(context.Variables[\"authorization-id\"])", "@(context.Variables[\"context-variable-name\"])", null, null, null)]
+        public void Compile_GetAuthorizationContextPolicy(string code, string expectedProviderId, string expectedAuthorizationId, string expectedContextVariableName, string expectedIdentityType, string expectedIdentity, string expectedIgnoreError)
+        {
+            // Arrange
+            var syntaxTree = CSharpSyntaxTree.ParseText(code);
+            var document = syntaxTree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().First();
+            var compiler = new CSharpPolicyCompiler(document);
+
+            // Act
+            var result = compiler.Compile();
+
+            // Assert
+            Assert.AreEqual(0, result.Diagnostics.Count());
+            var policy = result.Document.Element("inbound").Element("get-authorization-context");
+            Assert.IsNotNull(policy);
+            Assert.AreEqual(expectedProviderId, policy.Attribute("provider-id").Value);
+            Assert.AreEqual(expectedAuthorizationId, policy.Attribute("authorization-id").Value);
+            Assert.AreEqual(expectedContextVariableName, policy.Attribute("context-variable-name").Value);
+            if (expectedIdentityType != null)
+            {
+                Assert.AreEqual(expectedIdentityType, policy.Attribute("identity-type").Value);
+            }
+            if (expectedIdentity != null)
+            {
+                Assert.AreEqual(expectedIdentity, policy.Attribute("identity").Value);
+            }
+            if (expectedIgnoreError != null)
+            {
+                Assert.AreEqual(expectedIgnoreError, policy.Attribute("ignore-error").Value);
+            }
+        }
+
+        [TestMethod]
+        public void Compile_GetAuthorizationContextPolicy_WithMissingRequiredProperties()
+        {
+            // Arrange
+            var code = @"
+                using Azure.Api.Management.PolicyToolkit.Authoring;
+
+                public class TestDocument : IDocument
+                {
+                    public void Inbound(IInboundContext context)
+                    {
+                        context.GetAuthorizationContext(new GetAuthorizationContextConfig
+                        {
+                            ProviderId = ""provider-id""
+                        });
+                    }
+                }
+            ";
+
+            var syntaxTree = CSharpSyntaxTree.ParseText(code);
+            var document = syntaxTree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().First();
+            var compiler = new CSharpPolicyCompiler(document);
+
+            // Act
+            var result = compiler.Compile();
+
+            // Assert
+            Assert.AreEqual(1, result.Diagnostics.Count());
+            var diagnostic = result.Diagnostics.First();
+            Assert.AreEqual("APIM2008", diagnostic.Id);
+            Assert.IsTrue(diagnostic.GetMessage().Contains("Required 'AuthorizationId' parameter was not defined for 'get-authorization-context' policy"));
+        }
+
+        [TestMethod]
+        public void Compile_GetAuthorizationContextPolicy_WithInvalidValues()
+        {
+            // Arrange
+            var code = @"
+                using Azure.Api.Management.PolicyToolkit.Authoring;
+
+                public class TestDocument : IDocument
+                {
+                    public void Inbound(IInboundContext context)
+                    {
+                        context.GetAuthorizationContext(new GetAuthorizationContextConfig
+                        {
+                            ProviderId = ""provider-id"",
+                            AuthorizationId = ""authorization-id"",
+                            ContextVariableName = ""context-variable-name"",
+                            IdentityType = ""invalid-identity-type""
+                        });
+                    }
+                }
+            ";
+
+            var syntaxTree = CSharpSyntaxTree.ParseText(code);
+            var document = syntaxTree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().First();
+            var compiler = new CSharpPolicyCompiler(document);
+
+            // Act
+            var result = compiler.Compile();
+
+            // Assert
+            Assert.AreEqual(1, result.Diagnostics.Count());
+            var diagnostic = result.Diagnostics.First();
+            Assert.AreEqual("APIM2009", diagnostic.Id);
+            Assert.IsTrue(diagnostic.GetMessage().Contains("Invalid value 'invalid-identity-type' for parameter 'IdentityType' in 'get-authorization-context' policy"));
+        }
+    }
+}


### PR DESCRIPTION
Implement the `get-authorization-context` policy in the authoring interface and handle it in the compiler.

* **Authoring Interface:**
  - Add `GetAuthorizationContext` method to `IInboundContext` interface in `src/Authoring/IInboundContext.cs`.
  - Create `GetAuthorizationContextConfig` class in `src/Authoring/Configs/GetAuthorizationContextConfig.cs` to define the configuration for the policy.
  - Implement `Authorization` class in `src/Authoring/Expressions/Authorization.cs` to represent the authorization object.

* **Compiler:**
  - Add `GetAuthorizationContextCompiler` class in `src/Core/Compiling/Policy/GetAuthorizationContextCompiler.cs` to handle the `get-authorization-context` policy.
  - Update `CSharpPolicyCompiler` in `src/Core/Compiling/CSharpPolicyCompiler.cs` to reference `GetAuthorizationContextCompiler`.
  - Add errors related to `get-authorization-context` policy in `src/Core/Compiling/Diagnostics/CompilationErrors.cs`.

* **Tests:**
  - Add tests for `get-authorization-context` policy in `test/Test.Core/Compiling/GetAuthorizationContextTests.cs` to verify compilation of the policy with required and optional properties, policy expressions, and error handling.

