### PR TITLE
Add named value support and compiler default-value handling

### DIFF
--- a/src/Authoring/Attributes/ApimDefaultValueAttribute.cs
+++ b/src/Authoring/Attributes/ApimDefaultValueAttribute.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Authoring;
+
+/// <summary>
+/// Declares the APIM default value for an optional policy attribute.
+/// When a property's value matches this default, the compiler will not emit the XML attribute
+/// (APIM applies the default implicitly). The comparer also uses this to tolerate
+/// differences where one side explicitly states the default and the other omits it.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public class ApimDefaultValueAttribute(string value, string xmlAttributeName) : Attribute
+{
+    public string Value { get; } = value;
+    public string XmlAttributeName { get; } = xmlAttributeName;
+}

--- a/src/Authoring/Attributes/NamedValueAttribute.cs
+++ b/src/Authoring/Attributes/NamedValueAttribute.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Authoring;
+
+/// <summary>
+/// Marks an expression method as a named value reference.
+/// <para>
+/// Simple named value: <c>[NamedValue("MyKey")]</c> emits <c>{{MyKey}}</c> in XML.
+/// </para>
+/// <para>
+/// Template with embedded tokens: <c>[NamedValue("{{Api-Backend-Url}}/v2.0")]</c>
+/// emits the string as-is. Auto-detected when the value contains <c>{{</c>.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public class NamedValueAttribute(string value) : Attribute
+{
+    public string Value { get; } = value;
+
+    /// <summary>
+    /// True when the value is a template containing embedded {{token}} references.
+    /// </summary>
+    public bool IsTemplate => Value.Contains("{{");
+}

--- a/src/Authoring/Configs/CacheStoreValueConfig.cs
+++ b/src/Authoring/Configs/CacheStoreValueConfig.cs
@@ -19,10 +19,11 @@ public record CacheStoreValueConfig
 
     /// <summary>
     /// Required. Specifies the value to store in the cache.<br/>
+    /// Accepts any type; the APIM gateway can cache arbitrary objects, not only strings.<br/>
     /// Policy expressions are allowed.
     /// </summary>
     [ExpressionAllowed]
-    public required string Value { get; init; }
+    public required object Value { get; init; }
 
     /// <summary>
     /// Required. Specifies the duration in seconds for which the cached value is valid.<br/>

--- a/src/Authoring/Configs/HeaderConfig.cs
+++ b/src/Authoring/Configs/HeaderConfig.cs
@@ -14,6 +14,7 @@ public record HeaderConfig
     /// <summary>
     /// Specifies the action to take if the header already exists. Possible values are "override" and "skip". Policy expressions are allowed.
     /// </summary>
+    [ApimDefaultValue("override", "exists-action")]
     [ExpressionAllowed]
     public string? ExistsAction { get; init; }
 

--- a/src/Authoring/Configs/RateLimitByKeyConfig.cs
+++ b/src/Authoring/Configs/RateLimitByKeyConfig.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Authoring;
@@ -62,4 +62,9 @@ public record RateLimitByKeyConfig
     /// Name of the HTTP header to return the total number of calls allowed.
     /// </summary>
     public string? TotalCallsHeaderName { get; init; }
+
+    /// <summary>
+    /// Whether to increment the counter after the response is received. Default is false.
+    /// </summary>
+    public bool? IncrementAfterResponse { get; init; }
 }

--- a/src/Authoring/Expressions/IExpressionContext.cs
+++ b/src/Authoring/Expressions/IExpressionContext.cs
@@ -20,4 +20,10 @@ public interface IExpressionContext
     IUser User { get; }
     IReadOnlyDictionary<string, object> Variables { get; }
     Action<string> Trace { get; }
+
+    /// <summary>
+    /// Returns a named value that resolves at runtime. Compiles to {{name}} in XML.
+    /// Supports implicit conversion to string, int, bool, etc.
+    /// </summary>
+    dynamic NamedValue(string name);
 }

--- a/src/Core/Compiling/CompilerUtils.cs
+++ b/src/Core/Compiling/CompilerUtils.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
+using Microsoft.Azure.ApiManagement.PolicyToolkit.Authoring;
 using Microsoft.Azure.ApiManagement.PolicyToolkit.Compiling.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -49,43 +52,85 @@ public static class CompilerUtils
     public static string FindCode(this InvocationExpressionSyntax syntax, IDocumentCompilationContext context)
     {
         Compilation compilation = context.Compilation;
-        SemanticModel semanticModel = compilation.GetSemanticModel(syntax.SyntaxTree);
-        var symbolInfo = semanticModel.GetSymbolInfo(syntax.Expression);
-        var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.SingleOrDefault(s => s is IMethodSymbol);
 
-        if (symbol is not IMethodSymbol methodSymbol)
+        MethodDeclarationSyntax? expressionMethod = null;
+
+        // Try semantic resolution first (works when all types are available)
+        if (compilation.SyntaxTrees.Contains(syntax.SyntaxTree))
         {
+            SemanticModel semanticModel = compilation.GetSemanticModel(syntax.SyntaxTree);
+            var symbolInfo = semanticModel.GetSymbolInfo(syntax.Expression);
+            var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.SingleOrDefault(s => s is IMethodSymbol);
+
+            if (symbol is IMethodSymbol methodSymbol)
+            {
+                expressionMethod = methodSymbol.DeclaringSyntaxReferences
+                    .Select(r => r.GetSyntax())
+                    .OfType<MethodDeclarationSyntax>()
+                    .FirstOrDefault();
+            }
+        }
+
+        // Fall back to syntax-based lookup when semantic resolution fails
+        // (e.g., expression methods reference types not in the compilation)
+        if (expressionMethod is null)
+        {
+            var methodName = syntax.Expression switch
+            {
+                IdentifierNameSyntax id => id.Identifier.ValueText,
+                MemberAccessExpressionSyntax ma => ma.Name.Identifier.ValueText,
+                _ => null
+            };
+
+            if (methodName != null)
+            {
+                expressionMethod = context.SyntaxRoot
+                    .DescendantNodes()
+                    .OfType<MethodDeclarationSyntax>()
+                    .FirstOrDefault(m => m.Identifier.ValueText == methodName);
+            }
+        }
+
+        if (expressionMethod is null)
+        {
+            var name = syntax.Expression switch
+            {
+                IdentifierNameSyntax id => id.Identifier.ValueText,
+                MemberAccessExpressionSyntax ma => ma.Name.Identifier.ValueText,
+                _ => syntax.Expression.ToString()
+            };
             context.Report(Diagnostic.Create(
-                CompilationErrors.InvalidExpression,
-                syntax.GetLocation()
+                CompilationErrors.CannotFindMethodCode,
+                syntax.GetLocation(),
+                name
             ));
             return "";
         }
 
-        var expressionMethod = methodSymbol.DeclaringSyntaxReferences
-            .Select(r => r.GetSyntax())
-            .OfType<MethodDeclarationSyntax>()
-            .FirstOrDefault();
-
-        if (expressionMethod is null)
+        // Check for [NamedValue("...")] attribute
+        var namedValueAttr = expressionMethod.AttributeLists
+            .SelectMany(al => al.Attributes)
+            .FirstOrDefault(a => a.Name.ToString() is "NamedValue" or "NamedValueAttribute");
+        if (namedValueAttr?.ArgumentList?.Arguments.Count > 0)
         {
-            context.Report(Diagnostic.Create(
-                CompilationErrors.CannotFindMethodCode,
-                syntax.GetLocation(),
-                methodSymbol.Name
-            ));
-            return "";
+            var arg = namedValueAttr.ArgumentList.Arguments[0].Expression;
+            var value = arg is LiteralExpressionSyntax literal
+                ? literal.Token.ValueText
+                : arg.ToString().Trim('"');
+            // Auto-detect: if value contains {{ it's a template, emit as-is; otherwise wrap in {{}}
+            return value.Contains("{{") ? value : $"{{{{{value}}}}}";
         }
 
         expressionMethod = Normalize(expressionMethod);
 
         if (expressionMethod.Body != null)
         {
-            return $"@{expressionMethod.Body.ToFullString().TrimEnd()}";
+            return ReplaceNamedValueCalls($"@{expressionMethod.Body.ToFullString().Trim()}");
         }
         else if (expressionMethod.ExpressionBody != null)
         {
-            return $"@({expressionMethod.ExpressionBody.Expression.ToFullString().TrimEnd()})";
+            return ReplaceNamedValueCalls(
+                $"@({expressionMethod.ExpressionBody.Expression.ToFullString().Trim()})");
         }
         else
         {
@@ -234,6 +279,45 @@ public static class CompilerUtils
         return false;
     }
 
+    /// <summary>
+    /// Adds an XML attribute from config parameters, but skips emission when the value
+    /// matches the APIM default declared via <see cref="ApimDefaultValueAttribute"/> on the config property.
+    /// </summary>
+    public static bool AddAttributeSkipDefault<TConfig>(this XElement element,
+        IReadOnlyDictionary<string, InitializerValue> parameters, string key, string attName)
+    {
+        if (parameters.TryGetValue(key, out var value))
+        {
+            if (!IsApimDefault<TConfig>(key, value.Value?.ToString()))
+                element.Add(new XAttribute(attName, value.Value!));
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Adds an XML attribute only if the value does not match the APIM default
+    /// declared via <see cref="ApimDefaultValueAttribute"/> on the specified config property.
+    /// Used by method-based compilers where the value is known at compile time.
+    /// </summary>
+    public static void AddAttributeIfNotDefault<TConfig>(this XElement element,
+        string attName, string value, string configPropertyName)
+    {
+        if (!IsApimDefault<TConfig>(configPropertyName, value))
+            element.Add(new XAttribute(attName, value));
+    }
+
+    /// <summary>
+    /// Checks whether the given value matches the APIM default for a config property.
+    /// </summary>
+    public static bool IsApimDefault<TConfig>(string propertyName, string? value)
+    {
+        var attr = typeof(TConfig).GetProperty(propertyName)?
+            .GetCustomAttribute<ApimDefaultValueAttribute>();
+        return attr != null && string.Equals(value, attr.Value, StringComparison.OrdinalIgnoreCase);
+    }
+
     public static bool TryExtractingConfigParameter<T>(
         this InvocationExpressionSyntax node,
         IDocumentCompilationContext context,
@@ -291,6 +375,30 @@ public static class CompilerUtils
     {
         var unformatted = (T)new TriviaRemoverRewriter().Visit(node);
         return unformatted.NormalizeWhitespace("", "");
+    }
+
+    private static readonly Regex NamedValueCallPattern = new(
+        @"context\s*(?:\.\s*ExpressionContext\s*)?\.\s*NamedValue\s*\(\s*""([^""]*)""\s*\)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex ConcatArtifactPattern = new(
+        @"""\s*\+\s*(\{\{[^}]+\}\})\s*\+\s*(?:\$@?|@\$?)?""",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Replaces context.NamedValue("name") calls in expression code with {{name}} tokens.
+    /// Then cleans up concatenation artifacts from the decompiler's string-breaking approach.
+    /// </summary>
+    internal static string ReplaceNamedValueCalls(string expressionCode)
+    {
+        var result = NamedValueCallPattern.Replace(expressionCode, m => $"{{{{{m.Groups[1].Value}}}}}");
+        // Clean up decompiler artifacts: "prefix" + {{token}} + "suffix" → "prefix{{token}}suffix"
+        // Handles all string types: regular "", interpolated $"", verbatim @"", interpolated verbatim $@""/@$""
+        while (ConcatArtifactPattern.IsMatch(result))
+        {
+            result = ConcatArtifactPattern.Replace(result, "$1");
+        }
+        return result;
     }
 }
 

--- a/src/Core/Compiling/Policy/CacheStoreCompiler.cs
+++ b/src/Core/Compiling/Policy/CacheStoreCompiler.cs
@@ -32,7 +32,11 @@ public class CacheStoreCompiler : IMethodPolicyHandler
 
         if (arguments.Count == 2)
         {
-            element.Add(new XAttribute("cache-response", arguments[1].Expression.ProcessParameter(context)));
+            var cacheResponseValue = arguments[1].Expression.ProcessParameter(context);
+            if (cacheResponseValue != "null")
+            {
+                element.Add(new XAttribute("cache-response", cacheResponseValue));
+            }
         }
 
         context.AddPolicy(element);

--- a/src/Core/Compiling/Policy/RateLimitByKeyCompiler.cs
+++ b/src/Core/Compiling/Policy/RateLimitByKeyCompiler.cs
@@ -65,6 +65,7 @@ public class RateLimitByKeyCompiler : IMethodPolicyHandler
         element.AddAttribute(values, nameof(RateLimitByKeyConfig.RemainingCallsVariableName),
             "remaining-calls-variable-name");
         element.AddAttribute(values, nameof(RateLimitByKeyConfig.TotalCallsHeaderName), "total-calls-header-name");
+        element.AddAttribute(values, nameof(RateLimitByKeyConfig.IncrementAfterResponse), "increment-after-response");
 
         context.AddPolicy(element);
     }

--- a/src/Core/Compiling/Syntax/ExpressionStatementCompiler.cs
+++ b/src/Core/Compiling/Syntax/ExpressionStatementCompiler.cs
@@ -64,8 +64,8 @@ public class ExpressionStatementCompiler : ISyntaxCompiler
 
     /// <summary>
     /// Unwraps chained WithId() calls from an invocation expression.
-    /// For example: context.WithId("a").WithId("b").SetHeader(...) 
-    /// Returns the SetHeader invocation and sets context.PendingPolicyId to "b" (last wins).
+    /// Extracts the policy id and sets it on the context, but returns
+    /// the ORIGINAL invocation unchanged to preserve the SyntaxTree reference.
     /// </summary>
     private static InvocationExpressionSyntax UnwrapWithIdChain(
         IDocumentCompilationContext context,
@@ -74,38 +74,27 @@ public class ExpressionStatementCompiler : ISyntaxCompiler
         // Check if this is a method call on the result of WithId()
         // Pattern: something.WithId("id").Method(...)
         // The invocation.Expression would be: something.WithId("id").Method
-        // We need to check if "something.WithId("id")" is itself an InvocationExpression of WithId
+        // We extract the id but return the original invocation to preserve
+        // the SyntaxTree for semantic model lookups.
 
-        // Track if we've set the id (first WithId encountered is the outermost/last in chain)
-        var idSet = false;
-
-        while (invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
-               memberAccess.Expression is InvocationExpressionSyntax innerInvocation &&
-               innerInvocation.Expression is MemberAccessExpressionSyntax innerMemberAccess &&
-               innerMemberAccess.Name.ToString() == "WithId")
+        if (invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+            memberAccess.Expression is InvocationExpressionSyntax innerInvocation &&
+            innerInvocation.Expression is MemberAccessExpressionSyntax innerMemberAccess &&
+            innerMemberAccess.Name.ToString() == "WithId")
         {
-            // Extract the id from WithId("id") call - only take the first (outermost) one
-            if (!idSet && innerInvocation.ArgumentList.Arguments.Count == 1)
+            if (context.PendingPolicyId is null && innerInvocation.ArgumentList.Arguments.Count == 1)
             {
                 var argExpression = innerInvocation.ArgumentList.Arguments[0].Expression;
                 var idValue = ExtractConstantStringValue(context, argExpression);
                 if (idValue is not null)
                 {
                     context.PendingPolicyId = idValue;
-                    idSet = true;
                 }
             }
-
-            // Reconstruct the invocation without the WithId in the chain
-            // context.WithId("id").Method(args) -> context.Method(args)
-            var newMemberAccess = SyntaxFactory.MemberAccessExpression(
-                SyntaxKind.SimpleMemberAccessExpression,
-                innerMemberAccess.Expression,
-                memberAccess.Name);
-
-            invocation = invocation.WithExpression(newMemberAccess);
         }
 
+        // Return the original invocation unchanged - the caller extracts the
+        // method name from invocation.Expression as MemberAccessExpressionSyntax.Name
         return invocation;
     }
 

--- a/src/Testing/Emulator/Policies/SetVariableHandler.cs
+++ b/src/Testing/Emulator/Policies/SetVariableHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Azure.ApiManagement.PolicyToolkit.Authoring;
+using Microsoft.Azure.ApiManagement.PolicyToolkit.Testing.Expressions;
 
 namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Testing.Emulator.Policies;
 
@@ -16,5 +17,5 @@ internal class SetVariableHandler : PolicyHandler<string, object>
     public override string PolicyName => nameof(IInboundContext.SetVariable);
 
     protected override void Handle(GatewayContext context, string name, object value) =>
-        context.Variables[name] = value;
+        context.Variables[name] = value is ConfigValue configValue ? (string?)configValue ?? string.Empty : value;
 }

--- a/src/Testing/Expressions/ConfigValue.cs
+++ b/src/Testing/Expressions/ConfigValue.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Testing.Expressions;
+
+public readonly struct ConfigValue
+{
+    private readonly string? _value;
+
+    public ConfigValue(string? value) => _value = value;
+
+    public static implicit operator string?(ConfigValue cv) => cv._value;
+    public static implicit operator int(ConfigValue cv) =>
+        int.TryParse(cv._value, out var r) ? r : throw new FormatException($"Cannot convert '{cv._value}' to int.");
+    public static implicit operator bool(ConfigValue cv) =>
+        bool.TryParse(cv._value, out var r) ? r : throw new FormatException($"Cannot convert '{cv._value}' to bool.");
+    public static implicit operator long(ConfigValue cv) =>
+        long.TryParse(cv._value, out var r) ? r : throw new FormatException($"Cannot convert '{cv._value}' to long.");
+    public static implicit operator double(ConfigValue cv) =>
+        double.TryParse(cv._value, out var r) ? r : throw new FormatException($"Cannot convert '{cv._value}' to double.");
+    public static implicit operator Guid(ConfigValue cv) =>
+        Guid.TryParse(cv._value, out var r) ? r : throw new FormatException($"Cannot convert '{cv._value}' to Guid.");
+    public static implicit operator JToken(ConfigValue cv) =>
+        cv._value is not null ? JValue.CreateString(cv._value) : JValue.CreateNull();
+
+    public override string? ToString() => _value;
+}

--- a/src/Testing/Expressions/MockExpressionContext.cs
+++ b/src/Testing/Expressions/MockExpressionContext.cs
@@ -48,4 +48,18 @@ public class MockExpressionContext : IExpressionContext
     IProduct IExpressionContext.Product => Product;
 
     public Action<string> Trace { get; set; } = (message) => { };
+
+    private Dictionary<string, string> _namedValues = new();
+
+    public void SetNamedValues(IDictionary<string, string> values)
+    {
+        foreach (var kvp in values)
+            _namedValues[kvp.Key] = kvp.Value;
+    }
+
+    public dynamic NamedValue(string name)
+    {
+        var value = _namedValues.TryGetValue(name, out var v) ? v : null;
+        return new ConfigValue(value);
+    }
 }

--- a/src/Testing/TestDocument.cs
+++ b/src/Testing/TestDocument.cs
@@ -10,6 +10,9 @@ public class TestDocument(IDocument document)
 {
     public GatewayContext Context { get; init; } = new();
 
+    public void UseNamedValues(IDictionary<string, string> values)
+        => Context.SetNamedValues(values);
+
     /// <summary>
     /// Registers a fragment instance so that IncludeFragment calls with the given ID
     /// resolve to this instance instead of scanning assemblies via reflection.

--- a/test/Test.Core/Compiling/NamedValueTests.cs
+++ b/test/Test.Core/Compiling/NamedValueTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Compiling;
+
+[TestClass]
+public class NamedValueTests
+{
+    [TestMethod]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) {
+                context.SetVariable("backend-url", BackendUrl(context.ExpressionContext));
+            }
+            
+            [NamedValue("Api-Backend-Url")]
+            string BackendUrl(IExpressionContext context) => throw new NotImplementedException();
+        }
+        """,
+        """
+        <policies>
+            <inbound>
+                <set-variable name="backend-url" value="{{Api-Backend-Url}}" />
+            </inbound>
+        </policies>
+        """,
+        DisplayName = "Should compile simple NamedValue to {{token}}"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) {
+                context.SetVariable("url", BackendUrl(context.ExpressionContext));
+            }
+            
+            [NamedValue("{{Api-Backend-Url}}/v2.0/prediction")]
+            string BackendUrl(IExpressionContext context) => throw new NotImplementedException();
+        }
+        """,
+        """
+        <policies>
+            <inbound>
+                <set-variable name="url" value="{{Api-Backend-Url}}/v2.0/prediction" />
+            </inbound>
+        </policies>
+        """,
+        DisplayName = "Should compile NamedValue template with embedded tokens as-is"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) {
+                context.SetHeader("Authorization", AuthHeader(context.ExpressionContext));
+            }
+            
+            [NamedValue("{{Auth-Scheme}} {{Auth-Token}}")]
+            string AuthHeader(IExpressionContext context) => throw new NotImplementedException();
+        }
+        """,
+        """
+        <policies>
+            <inbound>
+                <set-header name="Authorization" exists-action="override">
+                    <value>{{Auth-Scheme}} {{Auth-Token}}</value>
+                </set-header>
+            </inbound>
+        </policies>
+        """,
+        DisplayName = "Should compile NamedValue template with multiple tokens"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) {
+                context.SetVariable("key", ApiKey(context.ExpressionContext));
+                context.SetVariable("endpoint", Endpoint(context.ExpressionContext));
+            }
+            
+            [NamedValue("My-Api-Key")]
+            string ApiKey(IExpressionContext context) => throw new NotImplementedException();
+            
+            [NamedValue("{{Service-Url}}/api/v1")]
+            string Endpoint(IExpressionContext context) => throw new NotImplementedException();
+        }
+        """,
+        """
+        <policies>
+            <inbound>
+                <set-variable name="key" value="{{My-Api-Key}}" />
+                <set-variable name="endpoint" value="{{Service-Url}}/api/v1" />
+            </inbound>
+        </policies>
+        """,
+        DisplayName = "Should compile mixed simple and template NamedValues"
+    )]
+    public void ShouldCompileNamedValue(string code, string expectedXml)
+    {
+        code.CompileDocument().Should().BeSuccessful().And.DocumentEquivalentTo(expectedXml);
+    }
+}


### PR DESCRIPTION
Named Values:
- NamedValue attribute with auto-detection: simple names emit {{name}}, templates containing {{tokens}} emit as-is
- IExpressionContext.NamedValue(string) for runtime resolution
- MockExpressionContext.SetNamedValues() for test configuration
- ConfigValue type for named value propagation through SetVariable
- ReplaceNamedValueCalls converts context.NamedValue() to {{tokens}}

ApimDefaultValue:
- ApimDefaultValueAttribute declares APIM schema defaults on config properties
- AddAttributeSkipDefault/AddAttributeIfNotDefault skip default emissions
- HeaderConfig: exists-action defaults to 'override'
- SetHeaderCompiler/SetQueryParameterCompiler: only emit exists-action when not the default value

Compiler improvements:
- FindCode: semantic resolution with syntax-based fallback
- ExpressionStatementCompiler: preserve original invocation in WithId
- TriviaRemoverRewriter: preserve // and /* */ comment trivia
- SetBodyCompiler: UseValueElement support for <value> child elements
- NormalizeWhitespace uses newlines to preserve // comments