### PR TITLE
feat(set-backend-service): add SfReplicaType attribute

### DIFF
--- a/src/Authoring/Configs/SetBackendServiceConfig.cs
+++ b/src/Authoring/Configs/SetBackendServiceConfig.cs
@@ -47,6 +47,12 @@ public record SetBackendServiceConfig
     public string? SfListenerName { get; init; }
 
     /// <summary>
+    /// Specifies the Service Fabric replica type (e.g., "primary" or "secondary"). Policy expressions are allowed.
+    /// </summary>
+    [ExpressionAllowed]
+    public string? SfReplicaType { get; init; }
+
+    /// <summary>
     /// Specifies the Dapr application ID. Policy expressions are allowed.
     /// </summary>
     [ExpressionAllowed]

--- a/src/Core/Compiling/Policy/SetBackendServiceCompiler.cs
+++ b/src/Core/Compiling/Policy/SetBackendServiceCompiler.cs
@@ -41,6 +41,7 @@ public class SetBackendServiceCompiler : IMethodPolicyHandler
         element.AddAttribute(values, nameof(SetBackendServiceConfig.SfServiceInstanceName), "sf-service-instance-name");
         element.AddAttribute(values, nameof(SetBackendServiceConfig.SfPartitionKey), "sf-partition-key");
         element.AddAttribute(values, nameof(SetBackendServiceConfig.SfListenerName), "sf-listener-name");
+        element.AddAttribute(values, nameof(SetBackendServiceConfig.SfReplicaType), "sf-replica-type");
 
         element.AddAttribute(values, nameof(SetBackendServiceConfig.DaprAppId), "dapr-app-id");
         element.AddAttribute(values, nameof(SetBackendServiceConfig.DaprMethod), "dapr-method");

--- a/src/Core/Decompiling/Policy/SetBackendServiceDecompiler.cs
+++ b/src/Core/Decompiling/Policy/SetBackendServiceDecompiler.cs
@@ -19,6 +19,7 @@ public class SetBackendServiceDecompiler : IPolicyDecompiler
         context.AddOptionalStringProp(props, element, "sf-service-instance-name", "SfServiceInstanceName");
         context.AddOptionalStringProp(props, element, "sf-partition-key", "SfPartitionKey");
         context.AddOptionalStringProp(props, element, "sf-listener-name", "SfListenerName");
+        context.AddOptionalStringProp(props, element, "sf-replica-type", "SfReplicaType");
         context.AddOptionalStringProp(props, element, "dapr-app-id", "DaprAppId");
         context.AddOptionalStringProp(props, element, "dapr-method", "DaprMethod");
         context.AddOptionalStringProp(props, element, "dapr-namespace", "DaprNamespace");

--- a/test/Test.Core/Compiling/SetBackendServiceTests.cs
+++ b/test/Test.Core/Compiling/SetBackendServiceTests.cs
@@ -324,6 +324,54 @@ public class SetBackendServiceTests
             public void Inbound(IInboundContext context) {
                 context.SetBackendService(new SetBackendServiceConfig 
                 { 
+                    BackendId = "id",
+                    SfReplicaType = "primary"
+                });
+            }
+        }
+        """,
+        """
+        <policies>
+            <inbound>
+                <set-backend-service backend-id="id" sf-replica-type="primary" />
+            </inbound>
+        </policies>
+        """,
+        DisplayName = "Should compile set backend service policy with sf replica type"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) {
+                context.SetBackendService(new SetBackendServiceConfig 
+                { 
+                    BackendId = "id",
+                    SfReplicaType = Exp(context.ExpressionContext)
+                });
+            }
+            public bool Exp(ExpressionContext context)
+                => context.User.Email.EndsWith("@contoso.example") ? "primary" : "secondary";
+        }
+        """,
+        """
+        <policies>
+            <inbound>
+                <set-backend-service backend-id="id" sf-replica-type="@(context.User.Email.EndsWith("@contoso.example") ? "primary" : "secondary")" />
+            </inbound>
+        </policies>
+        """,
+        DisplayName = "Should compile set backend service policy with expression in sf replica type"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) {
+                context.SetBackendService(new SetBackendServiceConfig 
+                { 
                     BackendId = "dapr",
                     DaprAppId = "app1"
                 });

--- a/test/Test.Decompiling/RoundTripTests.cs
+++ b/test/Test.Decompiling/RoundTripTests.cs
@@ -266,6 +266,7 @@ public class RoundTripTests
     [DataRow("log-to-eventhub.xml")]
     [DataRow("mock-response.xml")]
     [DataRow("redirect-content-urls.xml")]
+    [DataRow("set-backend-service.xml")]
     [DataRow("set-method.xml")]
     [DataRow("set-query-parameter.xml")]
     [DataRow("xml-to-json.xml")]

--- a/test/Test.Decompiling/TestData/set-backend-service.xml
+++ b/test/Test.Decompiling/TestData/set-backend-service.xml
@@ -1,0 +1,15 @@
+<policies>
+    <inbound>
+        <base />
+    </inbound>
+    <backend>
+        <base />
+        <set-backend-service backend-id="my-sf-backend" sf-resolve-condition="true" sf-service-instance-name="fabric:/myapp/myservice" sf-partition-key="partition1" sf-listener-name="listener1" sf-replica-type="primary" />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>


### PR DESCRIPTION
## Problem

The `set-backend-service` policy is missing the `sf-replica-type` XML attribute that the gateway supports. This attribute allows customers to specify Service Fabric replica types (primary/secondary).

## Solution

Add `SfReplicaType` property to `SetBackendServiceConfig` and update the compiler and decompiler.