### PR TITLE
feat(semantic-cache-lookup): add CacheId attribute

### DIFF
--- a/src/Authoring/Configs/SemanticCacheLookupConfig.cs
+++ b/src/Authoring/Configs/SemanticCacheLookupConfig.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Authoring;
@@ -45,6 +45,12 @@ public record SemanticCacheLookupConfig
     /// </summary>
     [ExpressionAllowed]
     public uint MaxMessageCount { get; init; }
+
+    /// <summary>
+    /// Optional. Identifier of a named cache instance to use for semantic cache lookup.<br/>
+    /// When specified, targets a specific external cache rather than the built-in cache.
+    /// </summary>
+    public string? CacheId { get; init; }
 
     /// <summary>
     /// Optional. Array of request properties to vary the cache by.<br/>

--- a/src/Core/Compiling/Policy/SemanticCacheLookupCompiler.cs
+++ b/src/Core/Compiling/Policy/SemanticCacheLookupCompiler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Xml.Linq;
@@ -74,6 +74,7 @@ public abstract class BaseSemanticCacheLookupCompiler : IMethodPolicyHandler
 
         element.AddAttribute(values, nameof(SemanticCacheLookupConfig.IgnoreSystemMessages), "ignore-system-messages");
         element.AddAttribute(values, nameof(SemanticCacheLookupConfig.MaxMessageCount), "max-message-count");
+        element.AddAttribute(values, nameof(SemanticCacheLookupConfig.CacheId), "cache-id");
 
         if (values.TryGetValue(nameof(SemanticCacheLookupConfig.VaryBy), out var varyByInitializer))
         {

--- a/src/Core/Decompiling/Policy/SemanticCacheLookupDecompiler.cs
+++ b/src/Core/Decompiling/Policy/SemanticCacheLookupDecompiler.cs
@@ -37,6 +37,7 @@ public abstract class BaseSemanticCacheLookupDecompiler : IPolicyDecompiler
         context.AddRequiredExprStringProp(props, element, "embeddings-backend-auth", "EmbeddingsBackendAuth");
         context.AddOptionalBoolExprProp(props, element, "ignore-system-messages", "IgnoreSystemMessages");
         context.AddOptionalUIntProp(props, element, "max-message-count", "MaxMessageCount");
+        context.AddOptionalStringProp(props, element, "cache-id", "CacheId");
 
         var varyByElements = element.Elements("vary-by").ToList();
         if (varyByElements.Count > 0)

--- a/test/Test.Core/Compiling/AzureOpenAiSemanticCacheLookupTests.cs
+++ b/test/Test.Core/Compiling/AzureOpenAiSemanticCacheLookupTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Compiling;
@@ -83,6 +83,32 @@ public class AzureOpenAiSemanticCacheLookupTests
         </policies>
         """,
         DisplayName = "Should compile azure-openai-semantic-cache-lookup policy with max-message-count"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context)
+            {
+                context.AzureOpenAiSemanticCacheLookup(new SemanticCacheLookupConfig
+                {
+                    ScoreThreshold = 0.05,
+                    EmbeddingsBackendId = "openai-backend",
+                    EmbeddingsBackendAuth = "system-assigned",
+                    CacheId = "my-external-cache"
+                });
+            }
+        }
+        """,
+        """
+        <policies>
+            <inbound>
+                <azure-openai-semantic-cache-lookup score-threshold="0.05" embeddings-backend-id="openai-backend" embeddings-backend-auth="system-assigned" cache-id="my-external-cache" />
+            </inbound>
+        </policies>
+        """,
+        DisplayName = "Should compile azure-openai-semantic-cache-lookup policy with cache-id"
     )]
     [DataRow(
         """

--- a/test/Test.Core/Compiling/LlmSemanticCacheLookupTests.cs
+++ b/test/Test.Core/Compiling/LlmSemanticCacheLookupTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Compiling;
@@ -83,6 +83,32 @@ public class LlmSemanticCacheLookupTests
         </policies>
         """,
         DisplayName = "Should compile llm-semantic-cache-lookup policy with max-message-count"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context)
+            {
+                context.LlmSemanticCacheLookup(new SemanticCacheLookupConfig
+                {
+                    ScoreThreshold = 0.05,
+                    EmbeddingsBackendId = "llm-backend",
+                    EmbeddingsBackendAuth = "system-assigned",
+                    CacheId = "my-external-cache"
+                });
+            }
+        }
+        """,
+        """
+        <policies>
+            <inbound>
+                <llm-semantic-cache-lookup score-threshold="0.05" embeddings-backend-id="llm-backend" embeddings-backend-auth="system-assigned" cache-id="my-external-cache" />
+            </inbound>
+        </policies>
+        """,
+        DisplayName = "Should compile llm-semantic-cache-lookup policy with cache-id"
     )]
     [DataRow(
         """

--- a/test/Test.Decompiling/TestData/azure-openai-semantic-cache-lookup.xml
+++ b/test/Test.Decompiling/TestData/azure-openai-semantic-cache-lookup.xml
@@ -1,17 +1,16 @@
 <policies>
-	<inbound>
-		<base />
-		<azure-openai-semantic-cache-lookup score-threshold="0.05" embeddings-backend-id="embeddings-backend" embeddings-backend-auth="system-assigned" ignore-system-messages="true" max-message-count="10">
-			<vary-by>user-id</vary-by>
-		</azure-openai-semantic-cache-lookup>
-	</inbound>
-	<backend>
-		<base />
-	</backend>
-	<outbound>
-		<base />
-	</outbound>
-	<on-error>
-		<base />
-	</on-error>
+<inbound>
+<base />
+<azure-openai-semantic-cache-lookup score-threshold="0.05" embeddings-backend-id="embeddings-backend" embeddings-backend-auth="system-assigned" ignore-system-messages="true" max-message-count="10" cache-id="my-cache">
+<vary-by>user-id</vary-by>
+</azure-openai-semantic-cache-lookup>
+</inbound>
+<backend>
+<base />
+</backend>
+<outbound><base />
+</outbound>
+<on-error>
+<base />
+</on-error>
 </policies>

--- a/test/Test.Decompiling/TestData/azure-openai-semantic-cache-lookup.xml
+++ b/test/Test.Decompiling/TestData/azure-openai-semantic-cache-lookup.xml
@@ -1,16 +1,17 @@
 <policies>
-<inbound>
-<base />
-<azure-openai-semantic-cache-lookup score-threshold="0.05" embeddings-backend-id="embeddings-backend" embeddings-backend-auth="system-assigned" ignore-system-messages="true" max-message-count="10" cache-id="my-cache">
-<vary-by>user-id</vary-by>
-</azure-openai-semantic-cache-lookup>
-</inbound>
-<backend>
-<base />
-</backend>
-<outbound><base />
-</outbound>
-<on-error>
-<base />
-</on-error>
+	<inbound>
+		<base />
+		<azure-openai-semantic-cache-lookup score-threshold="0.05" embeddings-backend-id="embeddings-backend" embeddings-backend-auth="system-assigned" ignore-system-messages="true" max-message-count="10" cache-id="my-cache">
+			<vary-by>user-id</vary-by>
+		</azure-openai-semantic-cache-lookup>
+	</inbound>
+	<backend>
+		<base />
+	</backend>
+	<outbound>
+		<base />
+	</outbound>
+	<on-error>
+		<base />
+	</on-error>
 </policies>

--- a/test/Test.Decompiling/TestData/llm-semantic-cache-lookup.xml
+++ b/test/Test.Decompiling/TestData/llm-semantic-cache-lookup.xml
@@ -1,15 +1,4 @@
 <policies>
-	<inbound>
-		<base />
-		<llm-semantic-cache-lookup score-threshold="0.05" embeddings-backend-id="my-embeddings" embeddings-backend-auth="managed-identity" />
-	</inbound>
-	<backend>
-		<base />
-	</backend>
-	<outbound>
-		<base />
-	</outbound>
-	<on-error>
-		<base />
-	</on-error>
+<inbound><base />
+<llm-semantic-cache-lookup score-threshold="0.05" embeddings-backend-id="my-embeddings" embeddings-backend-auth="managed-identity" cache-id="llm-cache" /></inbound><backend><base /></backend><outbound><base /></outbound><on-error><base /></on-error>
 </policies>

--- a/test/Test.Decompiling/TestData/llm-semantic-cache-lookup.xml
+++ b/test/Test.Decompiling/TestData/llm-semantic-cache-lookup.xml
@@ -1,4 +1,15 @@
 <policies>
-<inbound><base />
-<llm-semantic-cache-lookup score-threshold="0.05" embeddings-backend-id="my-embeddings" embeddings-backend-auth="managed-identity" cache-id="llm-cache" /></inbound><backend><base /></backend><outbound><base /></outbound><on-error><base /></on-error>
+	<inbound>
+		<base />
+		<llm-semantic-cache-lookup score-threshold="0.05" embeddings-backend-id="my-embeddings" embeddings-backend-auth="managed-identity" cache-id="llm-cache" />
+	</inbound>
+	<backend>
+		<base />
+	</backend>
+	<outbound>
+		<base />
+	</outbound>
+	<on-error>
+		<base />
+	</on-error>
 </policies>


### PR DESCRIPTION
## Problem

The semantic cache lookup policies (`azure-openai-semantic-cache-lookup` and `llm-semantic-cache-lookup`) are missing the `cache-id` XML attribute that the gateway supports. This attribute allows customers to target a specific named cache instance.

## Solution

Add `CacheId` property to `SemanticCacheLookupConfig` and update the compiler and decompiler.