### PR TITLE
feat(rate-limit-by-key): add FlexibleRetryWindow attribute

### DIFF
--- a/src/Authoring/Configs/RateLimitByKeyConfig.cs
+++ b/src/Authoring/Configs/RateLimitByKeyConfig.cs
@@ -67,4 +67,9 @@ public record RateLimitByKeyConfig
     /// Whether to increment the counter after the response is received. Default is false.
     /// </summary>
     public bool? IncrementAfterResponse { get; init; }
+
+    /// <summary>
+    /// Whether to use a flexible retry window. When true, the retry-after period adjusts dynamically.
+    /// </summary>
+    public bool? FlexibleRetryWindow { get; init; }
 }

--- a/src/Core/Compiling/Policy/RateLimitByKeyCompiler.cs
+++ b/src/Core/Compiling/Policy/RateLimitByKeyCompiler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Xml.Linq;
@@ -66,6 +66,7 @@ public class RateLimitByKeyCompiler : IMethodPolicyHandler
             "remaining-calls-variable-name");
         element.AddAttribute(values, nameof(RateLimitByKeyConfig.TotalCallsHeaderName), "total-calls-header-name");
         element.AddAttribute(values, nameof(RateLimitByKeyConfig.IncrementAfterResponse), "increment-after-response");
+        element.AddAttribute(values, nameof(RateLimitByKeyConfig.FlexibleRetryWindow), "flexible-retry-window");
 
         context.AddPolicy(element);
     }

--- a/src/Core/Decompiling/Policy/RateLimitByKeyDecompiler.cs
+++ b/src/Core/Decompiling/Policy/RateLimitByKeyDecompiler.cs
@@ -24,6 +24,7 @@ public class RateLimitByKeyDecompiler : IPolicyDecompiler
         context.AddOptionalStringProp(props, element, "remaining-calls-variable-name", "RemainingCallsVariableName");
         context.AddOptionalStringProp(props, element, "total-calls-header-name", "TotalCallsHeaderName");
         context.AddOptionalBoolProp(props, element, "increment-after-response", "IncrementAfterResponse");
+        context.AddOptionalBoolProp(props, element, "flexible-retry-window", "FlexibleRetryWindow");
         PolicyDecompilerContext.EmitConfigCall(writer, prefix, "RateLimitByKey", "RateLimitByKeyConfig", props);
     }
 }


### PR DESCRIPTION
## Problem

The `rate-limit-by-key` policy is missing the `flexible-retry-window` XML attribute that the gateway supports. This attribute controls whether the retry window adjusts dynamically.

## Solution

Add `FlexibleRetryWindow` property to `RateLimitByKeyConfig` and update the compiler and decompiler.