### PR TITLE
feat(set-body): add HtmlDecodeExpression attribute

### DIFF
--- a/src/Authoring/Configs/SetBodyConfig.cs
+++ b/src/Authoring/Configs/SetBodyConfig.cs
@@ -28,4 +28,10 @@ public record SetBodyConfig
     /// Optional. When true, wraps the body content in a &lt;value&gt; child element.
     /// </summary>
     public bool? UseValueElement { get; init; }
+
+    /// <summary>
+    /// Optional. Controls whether HTML entity decoding is applied to the expression result in Liquid templates.
+    /// Default is true.
+    /// </summary>
+    public bool? HtmlDecodeExpression { get; init; }
 }

--- a/src/Core/Compiling/Policy/SetBodyCompiler.cs
+++ b/src/Core/Compiling/Policy/SetBodyCompiler.cs
@@ -74,6 +74,11 @@ public class SetBodyCompiler : IMethodPolicyHandler
                     element.Add(new XAttribute("parse-date", parseDate.Value!));
                 }
 
+                if (contentType.NamedValues.TryGetValue(nameof(SetBodyConfig.HtmlDecodeExpression), out var htmlDecode))
+                {
+                    element.Add(new XAttribute("html-decode-expression", htmlDecode.Value!));
+                }
+
                 if (contentType.NamedValues.TryGetValue(nameof(SetBodyConfig.UseValueElement), out var useVal) &&
                     useVal.Value == "true")
                 {
@@ -121,6 +126,7 @@ public class SetBodyCompiler : IMethodPolicyHandler
         bodyElement.AddAttribute(config, nameof(BodyConfig.Template), "template");
         bodyElement.AddAttribute(config, nameof(BodyConfig.XsiNil), "xsi-nil");
         bodyElement.AddAttribute(config, nameof(BodyConfig.ParseDate), "parse-date");
+        bodyElement.AddAttribute(config, nameof(BodyConfig.HtmlDecodeExpression), "html-decode-expression");
 
         if (useValueElement)
             bodyElement.Add(new XElement("value", content.Value!));

--- a/src/Core/Decompiling/Policy/SetBodyDecompiler.cs
+++ b/src/Core/Decompiling/Policy/SetBodyDecompiler.cs
@@ -29,6 +29,7 @@ public class SetBodyDecompiler : IPolicyDecompiler
         context.AddOptionalStringProp(configProps, element, "template", "Template");
         context.AddOptionalStringProp(configProps, element, "xsi-nil", "XsiNil");
         context.AddOptionalBoolProp(configProps, element, "parse-date", "ParseDate");
+        context.AddOptionalBoolProp(configProps, element, "html-decode-expression", "HtmlDecodeExpression");
         if (valueChild != null)
             configProps.Add("UseValueElement = true");
 

--- a/test/Test.Core/Compiling/SetBodyTests.cs
+++ b/test/Test.Core/Compiling/SetBodyTests.cs
@@ -175,6 +175,57 @@ public class SetBodyTests
         """,
         DisplayName = "Should compile set body policy with UseValueElement wrapping content"
     )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) {
+                context.SetBody("inbound", new SetBodyConfig {
+                    HtmlDecodeExpression = true,
+                });
+            }
+            public void Outbound(IOutboundContext context) {
+                context.SetBody("outbound", new SetBodyConfig {
+                    HtmlDecodeExpression = false,
+                });
+            }
+        }
+        """,
+        """
+        <policies>
+            <inbound>
+                <set-body html-decode-expression="true">inbound</set-body>
+            </inbound>
+            <outbound>
+                <set-body html-decode-expression="false">outbound</set-body>
+            </outbound>
+        </policies>
+        """,
+        DisplayName = "Should compile set body policy with HtmlDecodeExpression in config"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) {
+                context.SetBody("inbound", new SetBodyConfig {
+                    Template = "liquid",
+                    HtmlDecodeExpression = false,
+                });
+            }
+        }
+        """,
+        """
+        <policies>
+            <inbound>
+                <set-body template="liquid" html-decode-expression="false">inbound</set-body>
+            </inbound>
+        </policies>
+        """,
+        DisplayName = "Should compile set body policy with template and HtmlDecodeExpression"
+    )]
     public void ShouldCompileForwardRequestPolicy(string code, string expectedXml)
     {
         code.CompileDocument().Should().BeSuccessful().And.DocumentEquivalentTo(expectedXml);


### PR DESCRIPTION
## Problem

The `set-body` policy is missing the `html-decode-expression` XML attribute that the gateway supports. This attribute controls whether HTML entity decoding is applied to the expression result in Liquid templates (default: true).

## Solution

Add `HtmlDecodeExpression` property to `SetBodyConfig` (inherited by `BodyConfig`) and update the compiler and decompiler to handle the `html-decode-expression` XML attribute in both standalone `set-body` and `set-body` within `send-request`.