### PR TITLE
feat(send-request): add BufferResponse and FailOnErrorStatusCode attributes

### DIFF
--- a/src/Authoring/Configs/SendRequestConfig.cs
+++ b/src/Authoring/Configs/SendRequestConfig.cs
@@ -29,6 +29,8 @@ public record SendRequestConfig
     /// Specifies whether to ignore errors. If set to true, errors are ignored.
     /// </summary>
     public bool? IgnoreError { get; init; }
+    public bool? BufferResponse { get; init; }
+    public bool? FailOnErrorStatusCode { get; init; }
 
     /// <summary>
     /// Specifies the URL to send the request to.

--- a/src/Core/Compiling/Policy/SendRequestCompiler.cs
+++ b/src/Core/Compiling/Policy/SendRequestCompiler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Xml.Linq;
@@ -37,6 +37,8 @@ public class SendRequestCompiler : IMethodPolicyHandler
         element.AddAttribute(values, nameof(SendRequestConfig.Mode), "mode");
         element.AddAttribute(values, nameof(SendRequestConfig.Timeout), "timeout");
         element.AddAttribute(values, nameof(SendRequestConfig.IgnoreError), "ignore-error");
+        element.AddAttribute(values, nameof(SendRequestConfig.BufferResponse), "buffer-response");
+        element.AddAttribute(values, nameof(SendRequestConfig.FailOnErrorStatusCode), "fail-on-error-status-code");
 
         if (values.TryGetValue(nameof(SendRequestConfig.Url), out var url))
         {

--- a/src/Core/Decompiling/Policy/SendRequestDecompiler.cs
+++ b/src/Core/Decompiling/Policy/SendRequestDecompiler.cs
@@ -17,6 +17,8 @@ public class SendRequestDecompiler : IPolicyDecompiler
         context.AddOptionalStringProp(props, element, "mode", "Mode");
         context.AddOptionalIntProp(props, element, "timeout", "Timeout");
         context.AddOptionalBoolProp(props, element, "ignore-error", "IgnoreError");
+        context.AddOptionalBoolProp(props, element, "buffer-response", "BufferResponse");
+        context.AddOptionalBoolProp(props, element, "fail-on-error-status-code", "FailOnErrorStatusCode");
 
         var url = element.Element("set-url");
         if (url != null)


### PR DESCRIPTION
## Summary

Add two missing XML attributes to the \send-request\ policy:

- **\uffer-response\** (\ool?\, default: \	rue\): Controls whether the response is buffered
- **\ail-on-error-status-code\** (\ool?\): Controls whether error status codes cause failures

## Changes

- \SendRequestConfig.cs\: Added \BufferResponse\ and \FailOnErrorStatusCode\ properties
- \SendRequestCompiler.cs\: Added attribute compilation for both new properties
- \SendRequestDecompiler.cs\: Added attribute decompilation for both new properties

## References

- [send-request policy docs](https://learn.microsoft.com/en-us/azure/api-management/send-request-policy)