### PR TITLE
fix(validate-jwt): rename DescriptionKeys to DecryptionKeys

### DIFF
--- a/src/Authoring/Configs/ValidateJwtConfig.cs
+++ b/src/Authoring/Configs/ValidateJwtConfig.cs
@@ -78,9 +78,9 @@ public record ValidateJwtConfig
     public KeyConfig[]? IssuerSigningKeys { get; init; }
 
     /// <summary>
-    /// Specifies the description keys.
+    /// Specifies the decryption keys.
     /// </summary>
-    public KeyConfig[]? DescriptionKeys { get; init; }
+    public KeyConfig[]? DecryptionKeys { get; init; }
 
     /// <summary>
     /// Specifies the allowed audiences.

--- a/src/Core/Compiling/Policy/ValidateJwtCompiler.cs
+++ b/src/Core/Compiling/Policy/ValidateJwtCompiler.cs
@@ -57,7 +57,7 @@ public class ValidateJwtCompiler : IMethodPolicyHandler
         }
 
         HandleKeys(context, element, values, nameof(ValidateJwtConfig.IssuerSigningKeys), "issuer-signing-keys");
-        HandleKeys(context, element, values, nameof(ValidateJwtConfig.DescriptionKeys), "decryption-keys");
+        HandleKeys(context, element, values, nameof(ValidateJwtConfig.DecryptionKeys), "decryption-keys");
         GenericCompiler.HandleList(element, values, nameof(ValidateJwtConfig.Audiences), "audiences", "audience");
         GenericCompiler.HandleList(element, values, nameof(ValidateJwtConfig.Issuers), "issuers", "issuer");
 

--- a/src/Core/Decompiling/Policy/ValidateJwtDecompiler.cs
+++ b/src/Core/Decompiling/Policy/ValidateJwtDecompiler.cs
@@ -36,7 +36,7 @@ public class ValidateJwtDecompiler : IPolicyDecompiler
         }
 
         EmitJwtKeys(context, element, "issuer-signing-keys", "IssuerSigningKeys", props);
-        EmitJwtKeys(context, element, "decryption-keys", "DescriptionKeys", props);
+        EmitJwtKeys(context, element, "decryption-keys", "DecryptionKeys", props);
 
         var audiences = element.Element("audiences")?.Elements("audience")
             .Select(e => PolicyDecompilerContext.GetElementText(e)).ToList();

--- a/test/Test.Core/Compiling/ValidateJwtTests.cs
+++ b/test/Test.Core/Compiling/ValidateJwtTests.cs
@@ -541,7 +541,7 @@ public class ValidateJwtTests
                 context.ValidateJwt(new ValidateJwtConfig
                 {
                     HeaderName = "Authorization",
-                    DescriptionKeys = [
+                    DecryptionKeys = [
                         new Base64KeyConfig { Id = "kid1", Value = "Base64Key" },
                         new CertificateKeyConfig { Id = "kid2", CertificateId = "certificate-id" },
                         new AsymmetricKeyConfig { Id = "kid3", Modulus = "modulus", Exponent = "exponent" },

--- a/test/Test.Decompiling/TestData/validate-jwt.xml
+++ b/test/Test.Decompiling/TestData/validate-jwt.xml
@@ -2,6 +2,10 @@
 	<inbound>
 		<base />
 		<validate-jwt header-name="Authorization" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized" require-expiration-time="true" require-signed-tokens="true">
+			<decryption-keys>
+				<key id="base64-key-id">dGVzdA==</key>
+				<key certificate-id="cert-1" />
+			</decryption-keys>
 			<audiences>
 				<audience>https://api.example.com</audience>
 			</audiences>


### PR DESCRIPTION
## Summary

Fix typo in validate-jwt policy: \DescriptionKeys\ was a misspelling of \DecryptionKeys\. Renamed across config, compiler, decompiler, and tests.

## Changes

- \src/Authoring/Configs/ValidateJwtConfig.cs\: Renamed property and doc comment
- \src/Core/Compiling/Policy/ValidateJwtCompiler.cs\: Updated \
ameof()\ reference
- \src/Core/Decompiling/Policy/ValidateJwtDecompiler.cs\: Updated string literal
- \	est/Test.Core/Compiling/ValidateJwtTests.cs\: Updated test usage