### PR TITLE
Add http-data-source policy support

### DIFF
--- a/src/Authoring/Configs/HttpDataSourceConfig.cs
+++ b/src/Authoring/Configs/HttpDataSourceConfig.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Authoring;
+
+/// <summary>
+/// Configuration for the http-data-source policy.
+/// </summary>
+public record HttpDataSourceConfig
+{
+    [ExpressionAllowed]
+    public string? Url { get; init; }
+    public string? Method { get; init; }
+    public HeaderConfig[]? Headers { get; init; }
+    public BodyConfig? Body { get; init; }
+    public IAuthenticationConfig? Authentication { get; init; }
+    public HeaderConfig[]? ResponseHeaders { get; init; }
+    public BodyConfig? ResponseBody { get; init; }
+}

--- a/src/Authoring/IBackendContext.cs
+++ b/src/Authoring/IBackendContext.cs
@@ -116,7 +116,13 @@ public interface IBackendContext : IHaveExpressionContext
     void GetAuthorizationContext(GetAuthorizationContextConfig config);
 
     /// <summary>
-    /// The policy inserts the policy fragment as-is at the location you select in the policy definition.<br />
+    /// Sends an HTTP request to a specified URL as a GraphQL resolver.
+    /// <a href="https://learn.microsoft.com/en-us/azure/api-management/http-data-source-policy">http-data-source policy</a>
+    /// </summary>
+    void HttpDataSource(HttpDataSourceConfig config);
+
+    /// <summary>
+    /// The policy inserts the policy fragment as-isat the location you select in the policy definition.<br />
     /// Compiled to <a href="https://learn.microsoft.com/en-us/azure/api-management/include-fragment-policy">include-fragment</a> policy.
     /// </summary>
     /// <param name="fragmentId">A string. Specifies the identifier (name) of a policy fragment created in the API Management instance. Policy expressions aren't allowed.</param>

--- a/src/Core/Compiling/Policy/HttpDataSourceCompiler.cs
+++ b/src/Core/Compiling/Policy/HttpDataSourceCompiler.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Xml.Linq;
+
+using Microsoft.Azure.ApiManagement.PolicyToolkit.Authoring;
+using Microsoft.Azure.ApiManagement.PolicyToolkit.Compiling.Diagnostics;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Compiling.Policy;
+
+public class HttpDataSourceCompiler : IMethodPolicyHandler
+{
+    public string MethodName => nameof(IBackendContext.HttpDataSource);
+
+    public void Handle(IDocumentCompilationContext context, InvocationExpressionSyntax node)
+    {
+        if (!node.TryExtractingConfigParameter<HttpDataSourceConfig>(context, "http-data-source", out var values))
+        {
+            return;
+        }
+
+        var element = new XElement("http-data-source");
+        var httpRequest = new XElement("http-request");
+
+        if (values.TryGetValue(nameof(HttpDataSourceConfig.Url), out var url))
+        {
+            httpRequest.Add(new XElement("set-url", url.Value!));
+        }
+
+        if (values.TryGetValue(nameof(HttpDataSourceConfig.Method), out var method))
+        {
+            httpRequest.Add(new XElement("set-method", method.Value!));
+        }
+
+        if (values.TryGetValue(nameof(HttpDataSourceConfig.Headers), out var headers))
+        {
+            BaseSetHeaderCompiler.HandleHeaders(context, httpRequest, headers);
+        }
+
+        if (values.TryGetValue(nameof(HttpDataSourceConfig.Body), out var body))
+        {
+            SetBodyCompiler.HandleBody(context, httpRequest, body);
+        }
+
+        if (values.TryGetValue(nameof(HttpDataSourceConfig.Authentication), out var authentication))
+        {
+            HandleAuthentication(context, httpRequest, authentication);
+        }
+
+        element.Add(httpRequest);
+
+        var hasResponseHeaders = values.TryGetValue(nameof(HttpDataSourceConfig.ResponseHeaders), out var responseHeaders);
+        var hasResponseBody = values.TryGetValue(nameof(HttpDataSourceConfig.ResponseBody), out var responseBody);
+
+        if (hasResponseHeaders || hasResponseBody)
+        {
+            var httpResponse = new XElement("http-response");
+
+            if (hasResponseHeaders)
+            {
+                BaseSetHeaderCompiler.HandleHeaders(context, httpResponse, responseHeaders!);
+            }
+
+            if (hasResponseBody)
+            {
+                SetBodyCompiler.HandleBody(context, httpResponse, responseBody!);
+            }
+
+            element.Add(httpResponse);
+        }
+
+        context.AddPolicy(element);
+    }
+
+    private void HandleAuthentication(IDocumentCompilationContext context, XElement element,
+        InitializerValue authentication)
+    {
+        var values = authentication.NamedValues;
+        if (values is null)
+        {
+            return;
+        }
+
+        switch (authentication.Type)
+        {
+            case nameof(CertificateAuthenticationConfig):
+                AuthenticationCertificateCompiler.HandleCertificateAuthentication(context, element, values,
+                    authentication.Node);
+                break;
+            case nameof(BasicAuthenticationConfig):
+                AuthenticationBasicCompiler.HandleBasicAuthentication(context, element, values, authentication.Node);
+                break;
+            case nameof(ManagedIdentityAuthenticationConfig):
+                AuthenticationManagedIdentityCompiler.HandleManagedIdentityAuthentication(context, element, values,
+                    authentication.Node);
+                break;
+            default:
+                context.Report(Diagnostic.Create(
+                    CompilationErrors.NotSupportedType,
+                    authentication.Node.GetLocation(),
+                    $"{element.Name}",
+                    authentication.Type
+                ));
+                break;
+        }
+    }
+}

--- a/src/Core/Decompiling/Policy/HttpDataSourceDecompiler.cs
+++ b/src/Core/Decompiling/Policy/HttpDataSourceDecompiler.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Xml.Linq;
+
+namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Decompiling.Policy;
+
+public class HttpDataSourceDecompiler : IPolicyDecompiler
+{
+    public string PolicyName => "http-data-source";
+
+    public void Decompile(CodeWriter writer, XElement element, string contextVar, PolicyDecompilerContext context)
+    {
+        var prefix = PolicyDecompilerContext.GetContextPrefix(element, contextVar);
+        var props = new List<string>();
+
+        var httpRequest = element.Element("http-request");
+        if (httpRequest != null)
+        {
+            var url = httpRequest.Element("set-url");
+            if (url != null)
+            {
+                var urlValue = PolicyDecompilerContext.GetElementText(url);
+                props.Add($"Url = {context.HandleValue(urlValue, "RequestUrl")}");
+            }
+
+            var method = httpRequest.Element("set-method");
+            if (method != null)
+            {
+                props.Add($"Method = {PolicyDecompilerContext.Literal(PolicyDecompilerContext.GetElementText(method))}");
+            }
+
+            var headers = httpRequest.Elements("set-header").ToList();
+            if (headers.Count > 0)
+            {
+                var headerConfigs = headers.Select(context.BuildHeaderConfigString).ToList();
+                props.Add($"Headers = new HeaderConfig[]\n            {{\n                {string.Join(",\n                ", headerConfigs)},\n            }}");
+            }
+
+            var body = httpRequest.Element("set-body");
+            if (body != null)
+            {
+                props.Add(context.BuildBodyConfigProperty(body));
+            }
+
+            SendRequestDecompilerHelper.EmitAuthentication(context, httpRequest, props);
+        }
+
+        var httpResponse = element.Element("http-response");
+        if (httpResponse != null)
+        {
+            var responseHeaders = httpResponse.Elements("set-header").ToList();
+            if (responseHeaders.Count > 0)
+            {
+                var headerConfigs = responseHeaders.Select(context.BuildHeaderConfigString).ToList();
+                props.Add($"ResponseHeaders = new HeaderConfig[]\n            {{\n                {string.Join(",\n                ", headerConfigs)},\n            }}");
+            }
+
+            var responseBody = httpResponse.Element("set-body");
+            if (responseBody != null)
+            {
+                var bodyProp = context.BuildBodyConfigProperty(responseBody);
+                // BuildBodyConfigProperty returns "Body = new BodyConfig { ... }"
+                // We need "ResponseBody = new BodyConfig { ... }"
+                props.Add("Response" + bodyProp);
+            }
+        }
+
+        PolicyDecompilerContext.EmitConfigCall(writer, prefix, "HttpDataSource", "HttpDataSourceConfig", props);
+    }
+}

--- a/test/Test.Core/Compiling/HttpDataSourceTests.cs
+++ b/test/Test.Core/Compiling/HttpDataSourceTests.cs
@@ -52,7 +52,6 @@ public class HttpDataSourceTests
                 {
                     Url = "https://example.com/api",
                     Method = "POST",
-                    Body = new BodyConfig { Content = "{\"query\": \"test\"}" }
                 });
             }
             public void Outbound(IOutboundContext context) { }
@@ -67,7 +66,6 @@ public class HttpDataSourceTests
                     <http-request>
                         <set-url>https://example.com/api</set-url>
                         <set-method>POST</set-method>
-                        <set-body>{"query": "test"}</set-body>
                     </http-request>
                 </http-data-source>
             </backend>
@@ -75,7 +73,7 @@ public class HttpDataSourceTests
             <on-error />
         </policies>
         """,
-        DisplayName = "Should compile http-data-source with POST method and body"
+        DisplayName = "Should compile http-data-source with method"
     )]
     [DataRow(
         """
@@ -89,16 +87,17 @@ public class HttpDataSourceTests
                 {
                     Url = "https://example.com/api",
                     Headers = [
-                        new HeaderConfig
-                        {
-                            Name = "Content-Type",
-                            Values = ["application/json"]
-                        }
+                        new HeaderConfig {
+                            Name = "content-type",
+                            ExistsAction = "append",
+                            Values = ["plain/text"],
+                        },
+                        new HeaderConfig {
+                            Name = "accept",
+                            ExistsAction = "override",
+                            Values = ["application/json", "application/xml"],
+                        },
                     ],
-                    Authentication = new ManagedIdentityAuthenticationConfig
-                    {
-                        Resource = "https://resource.azure.com"
-                    }
                 });
             }
             public void Outbound(IOutboundContext context) { }
@@ -112,10 +111,13 @@ public class HttpDataSourceTests
                 <http-data-source>
                     <http-request>
                         <set-url>https://example.com/api</set-url>
-                        <set-header name="Content-Type">
-                            <value>application/json</value>
+                        <set-header name="content-type" exists-action="append">
+                            <value>plain/text</value>
                         </set-header>
-                        <authentication-managed-identity resource="https://resource.azure.com" />
+                        <set-header name="accept">
+                            <value>application/json</value>
+                            <value>application/xml</value>
+                        </set-header>
                     </http-request>
                 </http-data-source>
             </backend>
@@ -123,7 +125,7 @@ public class HttpDataSourceTests
             <on-error />
         </policies>
         """,
-        DisplayName = "Should compile http-data-source with headers and managed identity auth"
+        DisplayName = "Should compile http-data-source with headers"
     )]
     [DataRow(
         """
@@ -136,7 +138,204 @@ public class HttpDataSourceTests
                 context.HttpDataSource(new HttpDataSourceConfig
                 {
                     Url = "https://example.com/api",
-                    ResponseBody = new BodyConfig { Content = "@(context.Response.Body.As(\"string\"))" }
+                    Body = new BodyConfig {
+                        Template = "liquid",
+                        XsiNil = "blank",
+                        ParseDate = false,
+                        Content = "body-content",
+                    },
+                });
+            }
+            public void Outbound(IOutboundContext context) { }
+            public void OnError(IOnErrorContext context) { }
+        }
+        """,
+        """
+        <policies>
+            <inbound />
+            <backend>
+                <http-data-source>
+                    <http-request>
+                        <set-url>https://example.com/api</set-url>
+                        <set-body template="liquid" xsi-nil="blank" parse-date="false">body-content</set-body>
+                    </http-request>
+                </http-data-source>
+            </backend>
+            <outbound />
+            <on-error />
+        </policies>
+        """,
+        DisplayName = "Should compile http-data-source with body"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) { }
+            public void Backend(IBackendContext context)
+            {
+                context.HttpDataSource(new HttpDataSourceConfig
+                {
+                    Url = "https://example.com/api",
+                    Body = new BodyConfig {
+                        Content = Exp(context.ExpressionContext),
+                    },
+                });
+            }
+            public void Outbound(IOutboundContext context) { }
+            public void OnError(IOnErrorContext context) { }
+            private string Exp(IExpressionContext context) => "bo" + "dy";
+        }
+        """,
+        """
+        <policies>
+            <inbound />
+            <backend>
+                <http-data-source>
+                    <http-request>
+                        <set-url>https://example.com/api</set-url>
+                        <set-body>@("bo" + "dy")</set-body>
+                    </http-request>
+                </http-data-source>
+            </backend>
+            <outbound />
+            <on-error />
+        </policies>
+        """,
+        DisplayName = "Should compile http-data-source with expression in body"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) { }
+            public void Backend(IBackendContext context)
+            {
+                context.HttpDataSource(new HttpDataSourceConfig
+                {
+                    Url = "https://example.com/api",
+                    Authentication = new CertificateAuthenticationConfig {
+                        CertificateId = "example-domain-cert",
+                    },
+                });
+            }
+            public void Outbound(IOutboundContext context) { }
+            public void OnError(IOnErrorContext context) { }
+        }
+        """,
+        """
+        <policies>
+            <inbound />
+            <backend>
+                <http-data-source>
+                    <http-request>
+                        <set-url>https://example.com/api</set-url>
+                        <authentication-certificate certificate-id="example-domain-cert" />
+                    </http-request>
+                </http-data-source>
+            </backend>
+            <outbound />
+            <on-error />
+        </policies>
+        """,
+        DisplayName = "Should compile http-data-source with certificate authentication"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) { }
+            public void Backend(IBackendContext context)
+            {
+                context.HttpDataSource(new HttpDataSourceConfig
+                {
+                    Url = "https://example.com/api",
+                    Authentication = new ManagedIdentityAuthenticationConfig {
+                        Resource = "https://resource.azure.com",
+                        ClientId = "example-client-id",
+                    },
+                });
+            }
+            public void Outbound(IOutboundContext context) { }
+            public void OnError(IOnErrorContext context) { }
+        }
+        """,
+        """
+        <policies>
+            <inbound />
+            <backend>
+                <http-data-source>
+                    <http-request>
+                        <set-url>https://example.com/api</set-url>
+                        <authentication-managed-identity resource="https://resource.azure.com" client-id="example-client-id" />
+                    </http-request>
+                </http-data-source>
+            </backend>
+            <outbound />
+            <on-error />
+        </policies>
+        """,
+        DisplayName = "Should compile http-data-source with managed identity authentication"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) { }
+            public void Backend(IBackendContext context)
+            {
+                context.HttpDataSource(new HttpDataSourceConfig
+                {
+                    Url = "https://example.com/api",
+                    Authentication = new BasicAuthenticationConfig {
+                        Username = "test-user",
+                        Password = "test-pass",
+                    },
+                });
+            }
+            public void Outbound(IOutboundContext context) { }
+            public void OnError(IOnErrorContext context) { }
+        }
+        """,
+        """
+        <policies>
+            <inbound />
+            <backend>
+                <http-data-source>
+                    <http-request>
+                        <set-url>https://example.com/api</set-url>
+                        <authentication-basic username="test-user" password="test-pass" />
+                    </http-request>
+                </http-data-source>
+            </backend>
+            <outbound />
+            <on-error />
+        </policies>
+        """,
+        DisplayName = "Should compile http-data-source with basic authentication"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) { }
+            public void Backend(IBackendContext context)
+            {
+                context.HttpDataSource(new HttpDataSourceConfig
+                {
+                    Url = "https://example.com/api",
+                    ResponseHeaders = [
+                        new HeaderConfig {
+                            Name = "x-custom-header",
+                            ExistsAction = "override",
+                            Values = ["custom-value"],
+                        },
+                    ],
                 });
             }
             public void Outbound(IOutboundContext context) { }
@@ -152,7 +351,46 @@ public class HttpDataSourceTests
                         <set-url>https://example.com/api</set-url>
                     </http-request>
                     <http-response>
-                        <set-body>@(context.Response.Body.As("string"))</set-body>
+                        <set-header name="x-custom-header">
+                            <value>custom-value</value>
+                        </set-header>
+                    </http-response>
+                </http-data-source>
+            </backend>
+            <outbound />
+            <on-error />
+        </policies>
+        """,
+        DisplayName = "Should compile http-data-source with response headers"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) { }
+            public void Backend(IBackendContext context)
+            {
+                context.HttpDataSource(new HttpDataSourceConfig
+                {
+                    Url = "https://example.com/api",
+                    ResponseBody = new BodyConfig { Content = "response-body" },
+                });
+            }
+            public void Outbound(IOutboundContext context) { }
+            public void OnError(IOnErrorContext context) { }
+        }
+        """,
+        """
+        <policies>
+            <inbound />
+            <backend>
+                <http-data-source>
+                    <http-request>
+                        <set-url>https://example.com/api</set-url>
+                    </http-request>
+                    <http-response>
+                        <set-body>response-body</set-body>
                     </http-response>
                 </http-data-source>
             </backend>
@@ -161,6 +399,128 @@ public class HttpDataSourceTests
         </policies>
         """,
         DisplayName = "Should compile http-data-source with response body"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) { }
+            public void Backend(IBackendContext context)
+            {
+                context.HttpDataSource(new HttpDataSourceConfig
+                {
+                    Url = "https://example.com/api",
+                    ResponseHeaders = [
+                        new HeaderConfig {
+                            Name = "x-response-header",
+                            Values = ["value1"],
+                        },
+                    ],
+                    ResponseBody = new BodyConfig { Content = "transformed-response" },
+                });
+            }
+            public void Outbound(IOutboundContext context) { }
+            public void OnError(IOnErrorContext context) { }
+        }
+        """,
+        """
+        <policies>
+            <inbound />
+            <backend>
+                <http-data-source>
+                    <http-request>
+                        <set-url>https://example.com/api</set-url>
+                    </http-request>
+                    <http-response>
+                        <set-header name="x-response-header">
+                            <value>value1</value>
+                        </set-header>
+                        <set-body>transformed-response</set-body>
+                    </http-response>
+                </http-data-source>
+            </backend>
+            <outbound />
+            <on-error />
+        </policies>
+        """,
+        DisplayName = "Should compile http-data-source with response headers and body"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) { }
+            public void Backend(IBackendContext context)
+            {
+                context.HttpDataSource(new HttpDataSourceConfig
+                {
+                    Url = "https://example.com/api",
+                    Method = "POST",
+                    Headers = [
+                        new HeaderConfig {
+                            Name = "content-type",
+                            Values = ["plain/text"],
+                        },
+                        new HeaderConfig {
+                            Name = "accept",
+                            Values = ["application/json", "application/xml"],
+                        },
+                    ],
+                    Body = new BodyConfig {
+                        Content = "request-body",
+                    },
+                    Authentication = new CertificateAuthenticationConfig {
+                        CertificateId = "example-domain-cert",
+                    },
+                    ResponseHeaders = [
+                        new HeaderConfig {
+                            Name = "x-custom",
+                            ExistsAction = "override",
+                            Values = ["custom-value"],
+                        },
+                    ],
+                    ResponseBody = new BodyConfig {
+                        Content = "response-body",
+                    },
+                });
+            }
+            public void Outbound(IOutboundContext context) { }
+            public void OnError(IOnErrorContext context) { }
+        }
+        """,
+        """
+        <policies>
+            <inbound />
+            <backend>
+                <http-data-source>
+                    <http-request>
+                        <set-url>https://example.com/api</set-url>
+                        <set-method>POST</set-method>
+                        <set-header name="content-type">
+                            <value>plain/text</value>
+                        </set-header>
+                        <set-header name="accept">
+                            <value>application/json</value>
+                            <value>application/xml</value>
+                        </set-header>
+                        <set-body>request-body</set-body>
+                        <authentication-certificate certificate-id="example-domain-cert" />
+                    </http-request>
+                    <http-response>
+                        <set-header name="x-custom">
+                            <value>custom-value</value>
+                        </set-header>
+                        <set-body>response-body</set-body>
+                    </http-response>
+                </http-data-source>
+            </backend>
+            <outbound />
+            <on-error />
+        </policies>
+        """,
+        DisplayName = "Should compile http-data-source with all options"
     )]
     public void HttpDataSource(string code, string expectedXml)
     {

--- a/test/Test.Core/Compiling/HttpDataSourceTests.cs
+++ b/test/Test.Core/Compiling/HttpDataSourceTests.cs
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Compiling;
+
+[TestClass]
+public class HttpDataSourceTests
+{
+    [TestMethod]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) { }
+            public void Backend(IBackendContext context)
+            {
+                context.HttpDataSource(new HttpDataSourceConfig
+                {
+                    Url = "https://example.com/api"
+                });
+            }
+            public void Outbound(IOutboundContext context) { }
+            public void OnError(IOnErrorContext context) { }
+        }
+        """,
+        """
+        <policies>
+            <inbound />
+            <backend>
+                <http-data-source>
+                    <http-request>
+                        <set-url>https://example.com/api</set-url>
+                    </http-request>
+                </http-data-source>
+            </backend>
+            <outbound />
+            <on-error />
+        </policies>
+        """,
+        DisplayName = "Should compile http-data-source with URL only"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) { }
+            public void Backend(IBackendContext context)
+            {
+                context.HttpDataSource(new HttpDataSourceConfig
+                {
+                    Url = "https://example.com/api",
+                    Method = "POST",
+                    Body = new BodyConfig { Content = "{\"query\": \"test\"}" }
+                });
+            }
+            public void Outbound(IOutboundContext context) { }
+            public void OnError(IOnErrorContext context) { }
+        }
+        """,
+        """
+        <policies>
+            <inbound />
+            <backend>
+                <http-data-source>
+                    <http-request>
+                        <set-url>https://example.com/api</set-url>
+                        <set-method>POST</set-method>
+                        <set-body>{"query": "test"}</set-body>
+                    </http-request>
+                </http-data-source>
+            </backend>
+            <outbound />
+            <on-error />
+        </policies>
+        """,
+        DisplayName = "Should compile http-data-source with POST method and body"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) { }
+            public void Backend(IBackendContext context)
+            {
+                context.HttpDataSource(new HttpDataSourceConfig
+                {
+                    Url = "https://example.com/api",
+                    Headers = [
+                        new HeaderConfig
+                        {
+                            Name = "Content-Type",
+                            Values = ["application/json"]
+                        }
+                    ],
+                    Authentication = new ManagedIdentityAuthenticationConfig
+                    {
+                        Resource = "https://resource.azure.com"
+                    }
+                });
+            }
+            public void Outbound(IOutboundContext context) { }
+            public void OnError(IOnErrorContext context) { }
+        }
+        """,
+        """
+        <policies>
+            <inbound />
+            <backend>
+                <http-data-source>
+                    <http-request>
+                        <set-url>https://example.com/api</set-url>
+                        <set-header name="Content-Type">
+                            <value>application/json</value>
+                        </set-header>
+                        <authentication-managed-identity resource="https://resource.azure.com" />
+                    </http-request>
+                </http-data-source>
+            </backend>
+            <outbound />
+            <on-error />
+        </policies>
+        """,
+        DisplayName = "Should compile http-data-source with headers and managed identity auth"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) { }
+            public void Backend(IBackendContext context)
+            {
+                context.HttpDataSource(new HttpDataSourceConfig
+                {
+                    Url = "https://example.com/api",
+                    ResponseBody = new BodyConfig { Content = "@(context.Response.Body.As(\"string\"))" }
+                });
+            }
+            public void Outbound(IOutboundContext context) { }
+            public void OnError(IOnErrorContext context) { }
+        }
+        """,
+        """
+        <policies>
+            <inbound />
+            <backend>
+                <http-data-source>
+                    <http-request>
+                        <set-url>https://example.com/api</set-url>
+                    </http-request>
+                    <http-response>
+                        <set-body>@(context.Response.Body.As("string"))</set-body>
+                    </http-response>
+                </http-data-source>
+            </backend>
+            <outbound />
+            <on-error />
+        </policies>
+        """,
+        DisplayName = "Should compile http-data-source with response body"
+    )]
+    public void HttpDataSource(string code, string expectedXml)
+    {
+        code.CompileDocument().Should().BeSuccessful().And.DocumentEquivalentTo(expectedXml);
+    }
+}


### PR DESCRIPTION
## Summary

Implement the \http-data-source\ GraphQL resolver policy, which sends HTTP requests to resolve GraphQL fields.

## Changes

- **\HttpDataSourceConfig.cs\** — Config record with 7 properties (Url, Method, Headers, Body, Authentication, ResponseHeaders, ResponseBody)
- **\HttpDataSourceCompiler.cs\** — Compiles C# \HttpDataSource()\ calls to \<http-data-source>\ XML with \<http-request>\ and optional \<http-response>\ children
- **\HttpDataSourceDecompiler.cs\** — Decompiles \<http-data-source>\ XML back to C# config calls
- **\IBackendContext.cs\** — Added \HttpDataSource(HttpDataSourceConfig config)\ method
- **\HttpDataSourceTests.cs\** — 4 test cases covering URL-only, POST+body, headers+auth, and response body scenarios

## Pattern

Follows the established \SendRequest\ compiler/decompiler pattern. Key difference: \http-data-source\ has no attributes on the root element — all content goes inside \<http-request>\ and \<http-response>\ child elements.