### PR TITLE
Add publish-event policy support

### DIFF
--- a/src/Authoring/Configs/PublishEventConfig.cs
+++ b/src/Authoring/Configs/PublishEventConfig.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Authoring;
+
+/// <summary>
+/// Configuration for the publish-event policy.<br />
+/// Specifies targets to which GraphQL subscription events are published.
+/// </summary>
+public record PublishEventConfig
+{
+    /// <summary>
+    /// Specifies an array of GraphQL subscription configurations to target.
+    /// </summary>
+    public required GraphqlSubscriptionConfig[] Subscriptions { get; init; }
+}
+
+/// <summary>
+/// Configuration for a single GraphQL subscription target within a publish-event policy.
+/// </summary>
+public record GraphqlSubscriptionConfig
+{
+    /// <summary>
+    /// Specifies the identifier of the GraphQL subscription.
+    /// </summary>
+    public required string Id { get; init; }
+}

--- a/src/Authoring/IOutboundContext.cs
+++ b/src/Authoring/IOutboundContext.cs
@@ -254,6 +254,15 @@ public interface IOutboundContext : IHaveExpressionContext
     void PublishToDarp(PublishToDarpConfig config);
 
     /// <summary>
+    /// Publishes an event to one or more GraphQL subscriptions.<br />
+    /// Compiled to <a href="https://learn.microsoft.com/en-us/azure/api-management/publish-event-policy">publish-event</a> policy.
+    /// </summary>
+    /// <param name="config">
+    /// Configuration specifying the GraphQL subscription targets for the publish-event policy.
+    /// </param>
+    void PublishEvent(PublishEventConfig config);
+
+    /// <summary>
     /// Redirects URLs in the response content to a specified hostname and scheme.<br/>
     /// This policy rewrites URLs in the response body to point to the gateway URL instead of the backend service URL.<br/>
     /// Useful when backend services return absolute URLs that need to be redirected through the API Management gateway.<br/>

--- a/src/Core/Compiling/Policy/PublishEventCompiler.cs
+++ b/src/Core/Compiling/Policy/PublishEventCompiler.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Xml.Linq;
+
+using Microsoft.Azure.ApiManagement.PolicyToolkit.Authoring;
+using Microsoft.Azure.ApiManagement.PolicyToolkit.Compiling.Diagnostics;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Compiling.Policy;
+
+public class PublishEventCompiler : IMethodPolicyHandler
+{
+    public string MethodName => nameof(IOutboundContext.PublishEvent);
+
+    public void Handle(IDocumentCompilationContext context, InvocationExpressionSyntax node)
+    {
+        if (!node.TryExtractingConfigParameter<PublishEventConfig>(context, "publish-event", out var values))
+        {
+            return;
+        }
+
+        var element = new XElement("publish-event");
+
+        if (!values.TryGetValue(nameof(PublishEventConfig.Subscriptions), out var subscriptionsInitializer))
+        {
+            context.Report(Diagnostic.Create(
+                CompilationErrors.RequiredParameterNotDefined,
+                node.GetLocation(),
+                "publish-event",
+                nameof(PublishEventConfig.Subscriptions)
+            ));
+            return;
+        }
+
+        var subscriptions = subscriptionsInitializer.UnnamedValues ?? Array.Empty<InitializerValue>();
+        if (subscriptions.Count == 0)
+        {
+            context.Report(Diagnostic.Create(
+                CompilationErrors.RequiredParameterIsEmpty,
+                subscriptionsInitializer.Node.GetLocation(),
+                "publish-event",
+                nameof(PublishEventConfig.Subscriptions)
+            ));
+            return;
+        }
+
+        var targetsElement = new XElement("targets");
+
+        foreach (var subscription in subscriptions)
+        {
+            if (!subscription.TryGetValues<GraphqlSubscriptionConfig>(out var result))
+            {
+                context.Report(Diagnostic.Create(
+                    CompilationErrors.PolicyArgumentIsNotOfRequiredType,
+                    subscription.Node.GetLocation(),
+                    "publish-event.graphql-subscriptions",
+                    nameof(GraphqlSubscriptionConfig)
+                ));
+                continue;
+            }
+
+            var subscriptionElement = new XElement("graphql-subscriptions");
+            if (!subscriptionElement.AddAttribute(result, nameof(GraphqlSubscriptionConfig.Id), "id"))
+            {
+                context.Report(Diagnostic.Create(
+                    CompilationErrors.RequiredParameterNotDefined,
+                    node.GetLocation(),
+                    "publish-event.graphql-subscriptions",
+                    nameof(GraphqlSubscriptionConfig.Id)
+                ));
+                continue;
+            }
+
+            targetsElement.Add(subscriptionElement);
+        }
+
+        element.Add(targetsElement);
+        context.AddPolicy(element);
+    }
+}

--- a/src/Core/Decompiling/Policy/PublishEventDecompiler.cs
+++ b/src/Core/Decompiling/Policy/PublishEventDecompiler.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Xml.Linq;
+
+namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Decompiling.Policy;
+
+public class PublishEventDecompiler : IPolicyDecompiler
+{
+    public string PolicyName => "publish-event";
+
+    public void Decompile(CodeWriter writer, XElement element, string contextVar, PolicyDecompilerContext context)
+    {
+        var prefix = PolicyDecompilerContext.GetContextPrefix(element, contextVar);
+        var props = new List<string>();
+
+        var targetsElement = element.Element("targets");
+        if (targetsElement != null)
+        {
+            var subscriptions = targetsElement.Elements("graphql-subscriptions").ToList();
+            if (subscriptions.Count > 0)
+            {
+                var items = new List<string>();
+                foreach (var sub in subscriptions)
+                {
+                    var id = sub.Attribute("id")?.Value;
+                    if (id != null)
+                    {
+                        items.Add($"new GraphqlSubscriptionConfig {{ Id = \"{id}\" }}");
+                    }
+                }
+
+                props.Add($"Subscriptions = [{string.Join(", ", items)}]");
+            }
+        }
+
+        PolicyDecompilerContext.EmitConfigCall(writer, prefix, "PublishEvent", "PublishEventConfig", props);
+    }
+}

--- a/test/Test.Core/Compiling/PublishEventTests.cs
+++ b/test/Test.Core/Compiling/PublishEventTests.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Compiling;
+
+[TestClass]
+public class PublishEventTests
+{
+    [TestMethod]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Outbound(IOutboundContext context) 
+            {
+                context.PublishEvent(new PublishEventConfig
+                {
+                    Subscriptions = [
+                        new GraphqlSubscriptionConfig { Id = "onUserCreated" }
+                    ]
+                });
+            }
+        }
+        """,
+        """
+        <policies>
+            <outbound>
+                <publish-event>
+                    <targets>
+                        <graphql-subscriptions id="onUserCreated" />
+                    </targets>
+                </publish-event>
+            </outbound>
+        </policies>
+        """,
+        DisplayName = "Should compile publish-event policy with single subscription"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Outbound(IOutboundContext context) 
+            {
+                context.PublishEvent(new PublishEventConfig
+                {
+                    Subscriptions = [
+                        new GraphqlSubscriptionConfig { Id = "onUserCreated" },
+                        new GraphqlSubscriptionConfig { Id = "onUserUpdated" }
+                    ]
+                });
+            }
+        }
+        """,
+        """
+        <policies>
+            <outbound>
+                <publish-event>
+                    <targets>
+                        <graphql-subscriptions id="onUserCreated" />
+                        <graphql-subscriptions id="onUserUpdated" />
+                    </targets>
+                </publish-event>
+            </outbound>
+        </policies>
+        """,
+        DisplayName = "Should compile publish-event policy with multiple subscriptions"
+    )]
+    public void ShouldCompilePublishEventPolicy(string code, string expectedXml)
+    {
+        code.CompileDocument().Should().BeSuccessful().And.DocumentEquivalentTo(expectedXml);
+    }
+}

--- a/test/Test.Decompiling/RoundTripTests.cs
+++ b/test/Test.Decompiling/RoundTripTests.cs
@@ -276,6 +276,7 @@ public class RoundTripTests
     [DataRow("cache-value.xml")]
     [DataRow("check-header.xml")]
     [DataRow("emit-metric.xml")]
+    [DataRow("publish-event.xml")]
     [DataRow("validate-jwt.xml")]
     public void RealPolicyFile_RoundTrips(string fileName)
     {

--- a/test/Test.Decompiling/TestData/publish-event.xml
+++ b/test/Test.Decompiling/TestData/publish-event.xml
@@ -1,0 +1,20 @@
+<policies>
+	<inbound>
+		<base />
+	</inbound>
+	<backend>
+		<base />
+	</backend>
+	<outbound>
+		<base />
+		<publish-event>
+			<targets>
+				<graphql-subscriptions id="onUserCreated" />
+				<graphql-subscriptions id="onUserUpdated" />
+			</targets>
+		</publish-event>
+	</outbound>
+	<on-error>
+		<base />
+	</on-error>
+</policies>


### PR DESCRIPTION
## Summary

Adds support for the `publish-event` policy, which publishes events to GraphQL subscriptions.

### Changes

- **PublishEventConfig.cs** - Config records for publish-event policy targets
- **PublishEventCompiler.cs** - Compiler that transforms C# PublishEvent() calls into publish-event XML
- **PublishEventDecompiler.cs** - Decompiler that reads publish-event XML back into C# config calls
- **IOutboundContext.cs** - Added PublishEvent(PublishEventConfig config) method
- **PublishEventTests.cs** - Two DataRow test cases (single and multiple subscriptions)

### Pattern

Follows the EmitMetricCompiler pattern for array child elements with an extra targets wrapper element, and PublishToDarpCompiler for overall structure.

### References

- [publish-event policy docs](https://learn.microsoft.com/en-us/azure/api-management/publish-event-policy)
