### PR TITLE
Add sql-data-source policy support

### DIFF
--- a/src/Authoring/Configs/SqlDataSourceConfig.cs
+++ b/src/Authoring/Configs/SqlDataSourceConfig.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Authoring;
+
+/// <summary>
+/// Configuration for the <a href="https://learn.microsoft.com/en-us/azure/api-management/sql-data-source-policy">sql-data-source</a> policy.<br/>
+/// Resolves a request to a backend SQL database.
+/// </summary>
+public record SqlDataSourceConfig
+{
+    public required SqlConnectionInfoConfig ConnectionInfo { get; init; }
+    public required SqlRequestConfig Request { get; init; }
+    [ExpressionAllowed] public string? SingleResult { get; init; }
+    [ExpressionAllowed] public string? Timeout { get; init; }
+}
+
+public record SqlConnectionInfoConfig
+{
+    [ExpressionAllowed] public required string ConnectionString { get; init; }
+    [ExpressionAllowed] public string? UseManagedIdentity { get; init; }
+    [ExpressionAllowed] public string? ClientId { get; init; }
+}
+
+public record SqlRequestConfig
+{
+    [ExpressionAllowed] public required string SqlStatement { get; init; }
+    public SqlParameterConfig[]? Parameters { get; init; }
+}
+
+public record SqlParameterConfig
+{
+    public required string Name { get; init; }
+    public required string SqlType { get; init; }
+    [ExpressionAllowed] public required string Value { get; init; }
+}

--- a/src/Authoring/IBackendContext.cs
+++ b/src/Authoring/IBackendContext.cs
@@ -337,6 +337,15 @@ public interface IBackendContext : IHaveExpressionContext
     void Trace(TraceConfig config);
 
     /// <summary>
+    /// Resolves a request to a backend SQL database.<br/>
+    /// Compiled to <a href="https://learn.microsoft.com/en-us/azure/api-management/sql-data-source-policy">sql-data-source</a> policy.
+    /// </summary>
+    /// <param name="config">
+    /// Configuration specifying SQL connection information, request details, and optional timeout settings.
+    /// </param>
+    void SqlDataSource(SqlDataSourceConfig config);
+
+    /// <summary>
     /// Executes its immediate child policies in parallel, and waits for either all or one of its immediate
     /// child policies to complete before it completes.<br/>
     /// The wait policy can have as its immediate child policies one or more of the following: send-request,

--- a/src/Core/Compiling/Policy/SqlDataSourceCompiler.cs
+++ b/src/Core/Compiling/Policy/SqlDataSourceCompiler.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Xml.Linq;
+
+using Microsoft.Azure.ApiManagement.PolicyToolkit.Authoring;
+using Microsoft.Azure.ApiManagement.PolicyToolkit.Compiling.Diagnostics;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Compiling.Policy;
+
+public class SqlDataSourceCompiler : IMethodPolicyHandler
+{
+    public string MethodName => nameof(IBackendContext.SqlDataSource);
+
+    public void Handle(IDocumentCompilationContext context, InvocationExpressionSyntax node)
+    {
+        if (!node.TryExtractingConfigParameter<SqlDataSourceConfig>(context, "sql-data-source",
+                out IReadOnlyDictionary<string, InitializerValue>? values))
+        {
+            return;
+        }
+
+        var element = new XElement("sql-data-source");
+        element.AddAttribute(values, nameof(SqlDataSourceConfig.SingleResult), "single-result");
+        element.AddAttribute(values, nameof(SqlDataSourceConfig.Timeout), "timeout");
+
+        if (!values.TryGetValue(nameof(SqlDataSourceConfig.ConnectionInfo), out var connectionInfoValue))
+        {
+            context.Report(Diagnostic.Create(CompilationErrors.RequiredParameterNotDefined, node.GetLocation(), "sql-data-source", nameof(SqlDataSourceConfig.ConnectionInfo)));
+            return;
+        }
+
+        if (!connectionInfoValue.TryGetValues<SqlConnectionInfoConfig>(out var connectionInfoValues))
+        {
+            context.Report(Diagnostic.Create(CompilationErrors.PolicyArgumentIsNotOfRequiredType, connectionInfoValue.Node.GetLocation(), "sql-data-source.connection-info", nameof(SqlConnectionInfoConfig)));
+            return;
+        }
+
+        var connectionInfoElement = new XElement("connection-info");
+
+        if (!connectionInfoValues.TryGetValue(nameof(SqlConnectionInfoConfig.ConnectionString), out var connStrValue) || connStrValue.Value is null)
+        {
+            context.Report(Diagnostic.Create(CompilationErrors.RequiredParameterNotDefined, connectionInfoValue.Node.GetLocation(), "sql-data-source.connection-info", nameof(SqlConnectionInfoConfig.ConnectionString)));
+            return;
+        }
+
+        var connectionStringElement = new XElement("connection-string", connStrValue.Value);
+        if (connectionInfoValues.TryGetValue(nameof(SqlConnectionInfoConfig.UseManagedIdentity), out var useMi) && useMi.Value is not null)
+        {
+            connectionStringElement.SetAttributeValue("use-managed-identity", useMi.Value);
+        }
+        if (connectionInfoValues.TryGetValue(nameof(SqlConnectionInfoConfig.ClientId), out var clientId) && clientId.Value is not null)
+        {
+            connectionStringElement.SetAttributeValue("client-id", clientId.Value);
+        }
+        connectionInfoElement.Add(connectionStringElement);
+        element.Add(connectionInfoElement);
+
+        if (!values.TryGetValue(nameof(SqlDataSourceConfig.Request), out var requestValue))
+        {
+            context.Report(Diagnostic.Create(CompilationErrors.RequiredParameterNotDefined, node.GetLocation(), "sql-data-source", nameof(SqlDataSourceConfig.Request)));
+            return;
+        }
+
+        if (!requestValue.TryGetValues<SqlRequestConfig>(out var requestValues))
+        {
+            context.Report(Diagnostic.Create(CompilationErrors.PolicyArgumentIsNotOfRequiredType, requestValue.Node.GetLocation(), "sql-data-source.request", nameof(SqlRequestConfig)));
+            return;
+        }
+
+        var requestElement = new XElement("request");
+
+        if (!requestValues.TryGetValue(nameof(SqlRequestConfig.SqlStatement), out var sqlStatementValue) || sqlStatementValue.Value is null)
+        {
+            context.Report(Diagnostic.Create(CompilationErrors.RequiredParameterNotDefined, requestValue.Node.GetLocation(), "sql-data-source.request", nameof(SqlRequestConfig.SqlStatement)));
+            return;
+        }
+
+        requestElement.Add(new XElement("sql-statement", sqlStatementValue.Value));
+
+        if (requestValues.TryGetValue(nameof(SqlRequestConfig.Parameters), out var parametersValue))
+        {
+            var parametersElement = new XElement("parameters");
+            var items = parametersValue.UnnamedValues ?? [];
+
+            foreach (var param in items)
+            {
+                if (!param.TryGetValues<SqlParameterConfig>(out var paramValues))
+                {
+                    context.Report(Diagnostic.Create(CompilationErrors.PolicyArgumentIsNotOfRequiredType, param.Node.GetLocation(), "sql-data-source.request.parameter", nameof(SqlParameterConfig)));
+                    continue;
+                }
+
+                if (!paramValues.TryGetValue(nameof(SqlParameterConfig.Name), out var nameValue) || nameValue.Value is null)
+                {
+                    context.Report(Diagnostic.Create(CompilationErrors.RequiredParameterNotDefined, param.Node.GetLocation(), "sql-data-source.request.parameter", nameof(SqlParameterConfig.Name)));
+                    continue;
+                }
+
+                if (!paramValues.TryGetValue(nameof(SqlParameterConfig.SqlType), out var typeValue) || typeValue.Value is null)
+                {
+                    context.Report(Diagnostic.Create(CompilationErrors.RequiredParameterNotDefined, param.Node.GetLocation(), "sql-data-source.request.parameter", nameof(SqlParameterConfig.SqlType)));
+                    continue;
+                }
+
+                if (!paramValues.TryGetValue(nameof(SqlParameterConfig.Value), out var valValue) || valValue.Value is null)
+                {
+                    context.Report(Diagnostic.Create(CompilationErrors.RequiredParameterNotDefined, param.Node.GetLocation(), "sql-data-source.request.parameter", nameof(SqlParameterConfig.Value)));
+                    continue;
+                }
+
+                var paramElement = new XElement("parameter");
+                paramElement.SetAttributeValue("name", nameValue.Value);
+                paramElement.SetAttributeValue("sql-type", typeValue.Value);
+                paramElement.Add(valValue.Value);
+                parametersElement.Add(paramElement);
+            }
+
+            requestElement.Add(parametersElement);
+        }
+
+        element.Add(requestElement);
+        context.AddPolicy(element);
+    }
+}

--- a/src/Core/Decompiling/Policy/SqlDataSourceDecompiler.cs
+++ b/src/Core/Decompiling/Policy/SqlDataSourceDecompiler.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Xml.Linq;
+
+namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Decompiling.Policy;
+
+public class SqlDataSourceDecompiler : IPolicyDecompiler
+{
+    public string PolicyName => "sql-data-source";
+
+    public void Decompile(CodeWriter writer, XElement element, string contextVar, PolicyDecompilerContext context)
+    {
+        var prefix = PolicyDecompilerContext.GetContextPrefix(element, contextVar);
+        var props = new List<string>();
+
+        var connectionInfoEl = element.Element("connection-info");
+        if (connectionInfoEl != null)
+        {
+            var ciProps = new List<string>();
+            var connStrEl = connectionInfoEl.Element("connection-string");
+            if (connStrEl != null)
+            {
+                ciProps.Add($"ConnectionString = {context.HandleValue(PolicyDecompilerContext.GetElementText(connStrEl), "ConnectionString")}");
+                var useMi = connStrEl.Attribute("use-managed-identity")?.Value;
+                if (useMi != null) ciProps.Add($"UseManagedIdentity = {context.HandleValue(useMi, "UseManagedIdentity")}");
+                var clientIdAttr = connStrEl.Attribute("client-id")?.Value;
+                if (clientIdAttr != null) ciProps.Add($"ClientId = {context.HandleValue(clientIdAttr, "ClientId")}");
+            }
+            props.Add($"ConnectionInfo = new SqlConnectionInfoConfig {{ {string.Join(", ", ciProps)} }}");
+        }
+
+        var requestEl = element.Element("request");
+        if (requestEl != null)
+        {
+            var reqProps = new List<string>();
+            var sqlStatementEl = requestEl.Element("sql-statement");
+            if (sqlStatementEl != null)
+                reqProps.Add($"SqlStatement = {context.HandleValue(PolicyDecompilerContext.GetElementText(sqlStatementEl), "SqlStatement")}");
+
+            var parametersEl = requestEl.Element("parameters");
+            if (parametersEl != null)
+            {
+                var parameters = parametersEl.Elements("parameter").Select(p =>
+                {
+                    var pProps = new List<string>
+                    {
+                        $"Name = {PolicyDecompilerContext.Literal(p.Attribute("name")?.Value ?? "")}",
+                        $"SqlType = {PolicyDecompilerContext.Literal(p.Attribute("sql-type")?.Value ?? "")}",
+                        $"Value = {context.HandleValue(PolicyDecompilerContext.GetElementText(p), "ParameterValue")}"
+                    };
+                    return $"new SqlParameterConfig {{ {string.Join(", ", pProps)} }}";
+                });
+                reqProps.Add($"Parameters = new SqlParameterConfig[] {{ {string.Join(", ", parameters)} }}");
+            }
+            props.Add($"Request = new SqlRequestConfig {{ {string.Join(", ", reqProps)} }}");
+        }
+
+        context.AddOptionalStringProp(props, element, "single-result", "SingleResult");
+        context.AddOptionalStringProp(props, element, "timeout", "Timeout");
+
+        PolicyDecompilerContext.EmitConfigCall(writer, prefix, "SqlDataSource", "SqlDataSourceConfig", props);
+    }
+}

--- a/test/Test.Core/Compiling/SqlDataSourceTests.cs
+++ b/test/Test.Core/Compiling/SqlDataSourceTests.cs
@@ -1,0 +1,229 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.ApiManagement.PolicyToolkit.Compiling;
+
+[TestClass]
+public class SqlDataSourceTests
+{
+    [TestMethod]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Backend(IBackendContext context) {
+                context.SqlDataSource(new SqlDataSourceConfig
+                {
+                    ConnectionInfo = new SqlConnectionInfoConfig
+                    {
+                        ConnectionString = "Server=tcp:myserver.database.windows.net;Database=mydb;",
+                    },
+                    Request = new SqlRequestConfig
+                    {
+                        SqlStatement = "SELECT * FROM Products",
+                    },
+                });
+            }
+        }
+        """,
+        """
+        <policies>
+            <backend>
+                <sql-data-source>
+                    <connection-info>
+                        <connection-string>Server=tcp:myserver.database.windows.net;Database=mydb;</connection-string>
+                    </connection-info>
+                    <request>
+                        <sql-statement>SELECT * FROM Products</sql-statement>
+                    </request>
+                </sql-data-source>
+            </backend>
+        </policies>
+        """,
+        DisplayName = "Should compile sql-data-source with simple query"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Backend(IBackendContext context) {
+                context.SqlDataSource(new SqlDataSourceConfig
+                {
+                    ConnectionInfo = new SqlConnectionInfoConfig
+                    {
+                        ConnectionString = "Server=tcp:myserver.database.windows.net;Database=mydb;",
+                    },
+                    Request = new SqlRequestConfig
+                    {
+                        SqlStatement = "SELECT * FROM Products WHERE Id = @Id",
+                        Parameters = new SqlParameterConfig[]
+                        {
+                            new SqlParameterConfig
+                            {
+                                Name = "@Id",
+                                SqlType = "Int",
+                                Value = "123",
+                            },
+                        },
+                    },
+                });
+            }
+        }
+        """,
+        """
+        <policies>
+            <backend>
+                <sql-data-source>
+                    <connection-info>
+                        <connection-string>Server=tcp:myserver.database.windows.net;Database=mydb;</connection-string>
+                    </connection-info>
+                    <request>
+                        <sql-statement>SELECT * FROM Products WHERE Id = @Id</sql-statement>
+                        <parameters>
+                            <parameter name="@Id" sql-type="Int">123</parameter>
+                        </parameters>
+                    </request>
+                </sql-data-source>
+            </backend>
+        </policies>
+        """,
+        DisplayName = "Should compile sql-data-source with parameters"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Backend(IBackendContext context) {
+                context.SqlDataSource(new SqlDataSourceConfig
+                {
+                    SingleResult = "true",
+                    ConnectionInfo = new SqlConnectionInfoConfig
+                    {
+                        ConnectionString = "Server=tcp:myserver.database.windows.net;Database=mydb;",
+                    },
+                    Request = new SqlRequestConfig
+                    {
+                        SqlStatement = "SELECT TOP 1 * FROM Products",
+                    },
+                });
+            }
+        }
+        """,
+        """
+        <policies>
+            <backend>
+                <sql-data-source single-result="true">
+                    <connection-info>
+                        <connection-string>Server=tcp:myserver.database.windows.net;Database=mydb;</connection-string>
+                    </connection-info>
+                    <request>
+                        <sql-statement>SELECT TOP 1 * FROM Products</sql-statement>
+                    </request>
+                </sql-data-source>
+            </backend>
+        </policies>
+        """,
+        DisplayName = "Should compile sql-data-source with single-result"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Backend(IBackendContext context) {
+                context.SqlDataSource(new SqlDataSourceConfig
+                {
+                    ConnectionInfo = new SqlConnectionInfoConfig
+                    {
+                        ConnectionString = "Server=tcp:myserver.database.windows.net;Database=mydb;",
+                        UseManagedIdentity = "true",
+                        ClientId = "my-client-id",
+                    },
+                    Request = new SqlRequestConfig
+                    {
+                        SqlStatement = "SELECT * FROM Products",
+                    },
+                });
+            }
+        }
+        """,
+        """
+        <policies>
+            <backend>
+                <sql-data-source>
+                    <connection-info>
+                        <connection-string use-managed-identity="true" client-id="my-client-id">Server=tcp:myserver.database.windows.net;Database=mydb;</connection-string>
+                    </connection-info>
+                    <request>
+                        <sql-statement>SELECT * FROM Products</sql-statement>
+                    </request>
+                </sql-data-source>
+            </backend>
+        </policies>
+        """,
+        DisplayName = "Should compile sql-data-source with managed identity"
+    )]
+    [DataRow(
+        """
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Backend(IBackendContext context) {
+                context.SqlDataSource(new SqlDataSourceConfig
+                {
+                    Timeout = "30",
+                    ConnectionInfo = new SqlConnectionInfoConfig
+                    {
+                        ConnectionString = "Server=tcp:myserver.database.windows.net;Database=mydb;",
+                    },
+                    Request = new SqlRequestConfig
+                    {
+                        SqlStatement = "SELECT * FROM Products WHERE Category = @Category AND Price = @MinPrice",
+                        Parameters = new SqlParameterConfig[]
+                        {
+                            new SqlParameterConfig
+                            {
+                                Name = "@Category",
+                                SqlType = "NVarChar",
+                                Value = "Electronics",
+                            },
+                            new SqlParameterConfig
+                            {
+                                Name = "@MinPrice",
+                                SqlType = "Decimal",
+                                Value = "99.99",
+                            },
+                        },
+                    },
+                });
+            }
+        }
+        """,
+        """
+        <policies>
+            <backend>
+                <sql-data-source timeout="30">
+                    <connection-info>
+                        <connection-string>Server=tcp:myserver.database.windows.net;Database=mydb;</connection-string>
+                    </connection-info>
+                    <request>
+                        <sql-statement>SELECT * FROM Products WHERE Category = @Category AND Price = @MinPrice</sql-statement>
+                        <parameters>
+                            <parameter name="@Category" sql-type="NVarChar">Electronics</parameter>
+                            <parameter name="@MinPrice" sql-type="Decimal">99.99</parameter>
+                        </parameters>
+                    </request>
+                </sql-data-source>
+            </backend>
+        </policies>
+        """,
+        DisplayName = "Should compile sql-data-source with multiple parameters and timeout"
+    )]
+    public void SqlDataSource(string code, string expectedXml)
+    {
+        code.CompileDocument().Should().BeSuccessful().And.DocumentEquivalentTo(expectedXml);
+    }
+}


### PR DESCRIPTION
## Summary
Adds support for the `sql-data-source` policy in the Policy Toolkit.

## Changes
- **SqlDataSourceConfig.cs**: 4 record types (SqlDataSourceConfig, SqlConnectionInfoConfig, SqlRequestConfig, SqlParameterConfig)
- **SqlDataSourceCompiler.cs**: Compiler implementing IMethodPolicyHandler for the sql-data-source policy
- **SqlDataSourceDecompiler.cs**: Decompiler implementing IPolicyDecompiler to reverse XML back to C#
- **IBackendContext.cs**: Added `SqlDataSource(SqlDataSourceConfig config)` method declaration
- **SqlDataSourceTests.cs**: 5 test cases covering simple query, parameters, single-result, managed identity, and multiple parameters with timeout

## Policy XML Structure
```xml
<sql-data-source single-result="true" timeout="10">
    <connection-info>
        <connection-string use-managed-identity="true">Server=...;Database=...</connection-string>
    </connection-info>
    <request>
        <sql-statement>SELECT * FROM Users WHERE Id = @Id</sql-statement>
        <parameters>
            <parameter name="@Id" sql-type="Int">123</parameter>
        </parameters>
    </request>
</sql-data-source>
```

All 5 tests pass.