### PR TITLE
Fix const folding to skip constants from referenced assemblies

### DIFF
--- a/src/Core/Compiling/ConstFoldingRewriter.cs
+++ b/src/Core/Compiling/ConstFoldingRewriter.cs
@@ -21,7 +21,9 @@ public class ConstFoldingRewriter : CSharpSyntaxRewriter
         var symbolInfo = _semanticModel.GetSymbolInfo(node);
         var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
 
-        if (symbol is IFieldSymbol { IsConst: true } field && field.ConstantValue is not null)
+        if (symbol is IFieldSymbol { IsConst: true } field
+            && field.ConstantValue is not null
+            && IsDefinedInSource(field))
         {
             return field.ConstantValue switch
             {
@@ -37,4 +39,11 @@ public class ConstFoldingRewriter : CSharpSyntaxRewriter
 
         return base.VisitMemberAccessExpression(node);
     }
+
+    // Only fold constants declared in the user's source code. Constants and enum members
+    // from referenced or runtime assemblies (e.g. System.*, Newtonsoft.*, Microsoft.*) must be
+    // left intact, otherwise things like StringComparison.OrdinalIgnoreCase would fold to their
+    // underlying value (5) and break the emitted policy expression.
+    private static bool IsDefinedInSource(IFieldSymbol field) =>
+        !field.DeclaringSyntaxReferences.IsDefaultOrEmpty;
 }

--- a/test/Test.Core/Compiling/ConstFoldingRewriterTests.cs
+++ b/test/Test.Core/Compiling/ConstFoldingRewriterTests.cs
@@ -37,4 +37,33 @@ public class ConstFoldingRewriterTests
     {
         code.CompileDocument(constClass).Should().BeSuccessful().And.DocumentEquivalentTo(expectedXml);
     }
+
+    [TestMethod]
+    [DataRow(
+        """
+        using System;
+
+        [Document]
+        public class PolicyDocument : IDocument
+        {
+            public void Inbound(IInboundContext context) {
+                context.SetVariable("match", IsMatch(context.ExpressionContext));
+            }
+            bool IsMatch(IExpressionContext context)
+                => string.Equals(context.Request.IpAddress, "10.0.0.1", StringComparison.OrdinalIgnoreCase);
+        }
+        """,
+        """
+        <policies>
+            <inbound>
+                <set-variable name="match" value="@(string.Equals(context.Request.IpAddress, "10.0.0.1", StringComparison.OrdinalIgnoreCase))" />
+            </inbound>
+        </policies>
+        """,
+        DisplayName = "Should preserve enum member access in expression body"
+    )]
+    public void ShouldPreserveEnumMemberInExpressionBody(string code, string expectedXml)
+    {
+        code.CompileDocument().Should().BeSuccessful().And.DocumentEquivalentTo(expectedXml);
+    }
 }


### PR DESCRIPTION
The ConstFoldingRewriter introduced in #251 folded any const field reference in an expression method body into its value. Because enum members are compiled as const fields whose ConstantValue is the underlying integer, this rewrote runtime enum members like StringComparison.OrdinalIgnoreCase into their numeric value (5), producing invalid APIM policy expressions.

Restrict folding to constants declared in the user's source (DeclaringSyntaxReferences present) so that constants and enum members from referenced/runtime assemblies (System.*, Newtonsoft.*, Microsoft.*, etc.) are emitted verbatim. Source-defined const fields continue to fold as before.

Fixes #250
Follow-up to #251